### PR TITLE
Minor TYPOs Fixed in docs/basic.md

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -388,10 +388,10 @@ def{
 // 让 Goroutine 执行一个闭包函数
 go def{
     sleep(0.5)
-    println("在 Gorouting 中执行了闭包函数喔")
+    println("在 Goroutine 中执行了闭包函数喔")
 }
 
-// aaa() 放在 Gourinte 中执行
+// aaa() 放在 Goroutine 中执行
 go aaa()
 
 // sleep 1 秒等待 Goroutine 执行完成


### PR DESCRIPTION
According to https://go.dev/tour/concurrency/1
> A goroutine is a lightweight thread managed by the Go runtime.

I assume that "goroutine" is the term that the author is intended to use.

In "docs/basic.md", term "goroutine" was spelt as "Gorouting" or "Gourinte",
obviously, these terms are typo.

So I correct them.

Signed-off-by: FredericDT <frederic.dt.twh@gmail.com>