### PR TITLE
chore(deploy): 解包前清空旧 build，清理服务器残留过时文件

### DIFF
--- a/.github/workflows/publish-to-oss.yml
+++ b/.github/workflows/publish-to-oss.yml
@@ -110,6 +110,7 @@ jobs:
           key: ${{ secrets.ONLINE_PRIV_KEY }}
           script: |
             cd /root/yaklang-io/
+            rm -rf build
             tar zxvf out.tgz
             rm -rf out.tgz
 


### PR DESCRIPTION
## Summary
- yaklang.com（SSH 服务器）部署此前只是覆盖式解包，未删除已移除的旧文件，导致 `/articles`、`/blog/blog/*` 等过时路径仍可访问
- 在服务器解包前增加 `rm -rf build`，使线上目录与最新构建严格一致（gh-pages 侧本就强制覆盖，无此问题）

## Test plan
- [x] 仅改动部署脚本；下一次 workflow_dispatch 部署后服务器旧文件将被清除

Made with [Cursor](https://cursor.com)