### PR TITLE
feat(homepage): 全新首页 Hero / Watercolor 背景 / Tab 式下载面板

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,458 @@
-# Yaklang Websites
+> **本仓库是 Yak Project 官网（[yaklang.com](https://yaklang.com) / [yaklang.io](https://yaklang.io)）的"故事板总稿"。**
+> 它既是官网维护者的协作入口（构建方式见末尾「网站维护」），也汇集了 Yak Project 的定位、产品矩阵、Showcase、开源故事时间线、用户故事与权威背书。
+> 文中标有 `【TODO 配图：...】` / `【TODO 视频剪辑：...】` 的位置，是需要补齐的真实素材，欢迎向运营同学提 PR。
 
-Yaklang Website is running on yaklang.io and yaklang.com
+---
+
+# 🛡️ Yak Project
+
+### 广泛使用的开源网络安全基础设施
+
+<p align="center">
+  <!-- TODO 配图：Yak Project 品牌主视觉（横向 hero banner，建议用 logo.svg + 品牌橙 #ff7d23 渐变背景） -->
+  <img src="static/img/logo.svg" alt="Yak Project Logo" width="220" />
+</p>
+
+<p align="center">
+  <strong>"让世界更安全，让安全更简单"</strong><br/>
+  团队口号：做难且正确的事
+</p>
+
+<p align="center">
+  <a href="https://github.com/yaklang/yaklang"><img alt="Yaklang Stars" src="https://img.shields.io/github/stars/yaklang/yaklang?style=social"/></a>
+  <a href="https://github.com/yaklang/yakit"><img alt="Yakit Stars" src="https://img.shields.io/github/stars/yaklang/yakit?style=social"/></a>
+  <a href="https://github.com/yaklang/yaklang/releases"><img alt="Yaklang Release" src="https://img.shields.io/github/release/yaklang/yaklang.svg"/></a>
+  <a href="https://github.com/yaklang/yaklang/releases"><img alt="Yaklang Downloads" src="https://img.shields.io/github/downloads/yaklang/yaklang/total.svg"/></a>
+  <a href="https://github.com/yaklang/yaklang/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/badge/license-AGPL%20v3-%23ff7d23.svg"/></a>
+  <a href="https://yaklang.com"><img alt="Site" src="https://img.shields.io/badge/site-yaklang.com-%233399dd.svg"/></a>
+</p>
+
+---
+
+## ✨ Hero：Yak Project 是什么
+
+**Yak Project 是广泛使用的开源网络安全基础设施。**
+
+它不是一个单一工具，而是一套**以「CDSL-YAK 领域编程语言」为内核、向外辐射出 GUI 平台、静态分析引擎、安全智能体、Java 工具链、漏洞靶场、AI 评测基准的完整技术体系**。从底层虚拟机 `YakVM`、静态单赋值 `YAK SSA`、漏洞建模语言 `SyntaxFlow`，到顶层的安全从业者日常使用的图形化工具，Yak Project 把"安全能力融合"做成了可被复用的工程基座。
+
+> 「**安全融合势在必行**」—— Yak 的起点不是再做一把"瑞士军刀"，而是去搭一块**让安全能力可以像积木一样被组合、被复用、被分发**的底层基建。
+>
+> 「**做难且正确的事**」—— 团队口号。
+
+**几个硬指标**（持续更新中）：
+
+| 维度 | 数据 |
+| --- | --- |
+| 核心语言仓库提交 | 14,000+ 次（截至 2026-07） |
+| Yakit 桌面端提交 | 8,400+ 次 |
+| 历史发布版本 | 600+ 个 tag |
+| 社区贡献者 | 50+ 人 |
+| 学术指导 | 电子科技大学网络空间安全学院 |
+| 权威鉴定 | 2024 / 2025 连续两年九位院士鉴定为「国内外首创、国际先进、国内领先」 |
+| 国家级荣誉 | 2023 年入选工信部信息通信领域十大科技进展 |
+
+> 【TODO 配图：Yak Project 技术体系全景图（建议把 YakVM / SSA / SyntaxFlow / Yaklang 放底层，Yakit / IRify / Memfit AI / JavaJive 放上层产品层）】
+
+---
+
+## 🧬 副 Hero：CDSL-YAK，为网络安全而生的领域编程语言
+
+<p align="center">
+  <strong>CDSL-YAK · Cybersecurity Domain Specific Language</strong><br/>
+  <em>"可能是安全领域最先进的领域编程语言（DSL）"</em>
+</p>
+
+**CDSL（Cybersecurity Domain Specific Language，网络安全领域专用编程语言）** 是 Yaklang 团队提出并被业界沿用的核心理念：与其用通用语言一次次重复"造安全工具的轮子"，不如直接为安全场景量身定制一门**图灵完备、强类型 + 动态类型、兼具编译字节码与解释执行**的编程语言。
+
+Yaklang 是 CDSL 理念的首个完整落地，包含一整套自研的编译器基础设施：
+
+| 编译器组件 | 角色 |
+| --- | --- |
+| **CDSL Yaklang** | 网络安全领域限定语言本体（语法 / 类型系统 / 运行时） |
+| **YakVM** | 网络安全领域限定语言的虚拟机（栈式字节码执行） |
+| **YAK SSA** | 静态分析友好的静态单赋值中间表示 |
+| **SyntaxFlow** | 语法模式匹配 DSL —— 漏洞特征代码描述语言 |
+| **LSP / DSP Server** | 语言服务器协议 + 调试协议服务器（IDE 级开发体验） |
+
+**为什么 CDSL 比通用语言更适合做安全？**
+
+- ✅ **简洁**：用最少的代码描述漏洞扫描、流量劫持、模糊测试这些安全高频场景；
+- ✅ **易用**：脚本即能力，单二进制、开箱即用，可跨 macOS / Linux / Windows 交叉编译；
+- ✅ **灵活**：支持热加载、嵌入式执行，可作为其他安全产品的"能力底座"被调用；
+- ✅ **可维护**：语法由上下文无关文法定义，IDE 友好，便于长期工程化；
+- ✅ **可靠**：强类型 + SSA 中间表示让程序分析"天生友好"。
+
+> 技术对比：`Golang ≈ Yaklang ≥ JVM Based Lang >> Python`
+>
+> Yak 的目标——成为安全领域的 **"Matlab"**，让"黑客编程"有一门属于自己的领域母语。
+
+📚 **CDSL 教材已正式出版**：《CDSL-YAK 网络安全领域编程语言—从入门到实践》
+
+> 【TODO 配图：CDSL 教材封面 + 编译器五件套架构图（YakVM / SSA / SyntaxFlow / LSP）】
+
+---
+
+## 🧩 产品矩阵
+
+Yak Project 的产品矩阵以 CDSL-YAK 为内核，自底向上覆盖**语言 → 平台 → 引擎 → 智能体 → 工具链**五个层次。下面是四个对外产品（与开源生态的关系见文末「开源生态」一节）。
+
+### 1️⃣ Yakit · 智能化交互式网络安全测试平台
+
+> **"安全融合"理念落地的图形化单兵作战平台，Yaklang 安全能力的最佳 GUI 实践。**
+
+| 项目 | 内容 |
+| --- | --- |
+| 定位 | 基于 Electron + Yaklang gRPC 引擎构建的交互式应用安全测试 ALL-IN-ONE 平台 |
+| 开源 | 2021-10-12 首发，完全开源、完全免费 |
+| 能力 | MITM 交互式劫持 · Web Fuzzer 模糊测试 · 被动扫描 · 端口扫描 · 爬虫 · 反连 · WebShell · BAS · 插件商店 · 空间引擎 · AI Agent |
+| 仓库 | [github.com/yaklang/yakit](https://github.com/yaklang/yakit) |
+| 截图 | 【TODO 配图：Yakit 主界面 + MITM 劫持界面 + Web Fuzzer 界面（三连图）】 |
+
+核心亮点：
+- 🥇 **可百分百替代 BurpSuite 的 MITM 劫持平台**，操作流与 Repeater / Intruder 一致；
+- 🎯 **难以复制的 MITM 被动扫描 GUI**——劫持即扫描；
+- ⚡ **嵌入式执行 + 热加载**：可在渗透的任何步骤动态执行 Yaklang 脚本调试流量；
+- 🧪 **全球第一个可视化的 Web 模糊测试工具**——Web Fuzzer + Fuzztag 语法；
+- 🧩 **高度插件化**：插件商店 + 本地仓库，覆盖渗透全流程。
+
+### 2️⃣ IRify · 兼具 SAST 与 AI 双引擎的代码安全分析系统
+
+> **"Static-Single-Assignment Bringing Clarity to Code"——编译器级 SSA IR 代码扫描技术。**
+
+| 项目 | 内容 |
+| --- | --- |
+| 定位 | 以 SSA 为核心的程序分析引擎 + 多语言代码审计平台，兼具 SAST 与 AI 双引擎 |
+| 首次落地 | 2023-07 SSA MVP；2023-12 SyntaxFlow；2025-03 正式命名 IRify；2026-05 Irify AI 代码审计上线 |
+| 引擎 | YAK SSA + SyntaxFlow 漏洞建模语言 + SQLite IR 数据库 |
+| 语言支持 | Java / SpringBoot 系列、Golang、PHP、JavaScript、Freemarker / SpEL / EL / JSP |
+| 站点 | [ssa.to](https://ssa.to) · [github.com/yaklang/yaklang](https://github.com/yaklang/yaklang) |
+| 截图 | 【TODO 配图：IRify 扫描结果 + SyntaxFlow 规则编辑器（双图）】 |
+
+核心亮点：
+- 🔬 **先进分析技术**：SSA + 双向数据流 + 控制流分析 + 全局分析 + 闭包分析；
+- 📜 **SyntaxFlow 规则语言**：用贴近"漏洞描述"的语法直接表达检测规则；
+- 🤖 **AI 双引擎**：2026 年加入 AI 代码审计，传统 SAST + 大模型协同定位真漏洞。
+
+### 3️⃣ Memfit AI · 新一代安全领域工作 Agent
+
+> **ReAct 与 Plan-Execute 递归耦合的混合智能体架构，融合宏观战略规划与微观战术执行。**
+
+| 项目 | 内容 |
+| --- | --- |
+| 定位 | 面向智能体系统的递归式双引擎混合架构，由 Yaklang 驱动 |
+| 首次落地 | 2025-08 aireact 框架成型；后续衍生出 `-memfit` 发行版 |
+| 架构 | 宏观 Plan-Execute 战略规划 + 微观 ReAct 战术执行，递归耦合 |
+| 站点 | [memfit.ai](https://memfit.ai) · [github.com/yaklang/yaklang/tree/main/common/ai/aid](https://github.com/yaklang/yaklang/tree/main/common/ai/aid) |
+| 截图 | 【TODO 配图：Memfit AI Agent 执行轨迹（Plan / Execute / ReAct 分层视图）】 |
+
+核心亮点：
+- 🧠 **递归式双引擎**：复杂任务可被逐层分解，战略层与战术层互相驱动；
+- 🔧 **工具原生**：内置 Yaklang 全栈安全能力作为可调用工具；
+- 📊 **可评测**：配合 HackBenchmark 基准，对真实 Web 漏洞做可复现的攻防评测。
+
+### 4️⃣ JavaJive · 业界领先的工业可用 Java 代码反编译器
+
+> **纯 Go 实现的 Java 工具箱：反编译 / 类解析 / 序列化，单二进制、无需 JDK。**
+
+| 项目 | 内容 |
+| --- | --- |
+| 定位 | 从 yaklang 抽取并裁剪而成的纯 Go Java 工具链 |
+| 能力 | 反编译 `.class` / `.jar` / `.war` · 解析类结构 · Java 序列化与 JSON 互转 |
+| 特性 | 单二进制、无需 JDK、可交叉编译，工业级可用 |
+| 仓库 | [github.com/yaklang/javajive](https://github.com/yaklang/javajive) |
+| 截图 | 【TODO 配图：JavaJive 反编译 .jar 的效果对比图（JD-GUI vs JavaJive）】 |
+
+---
+
+## 🎬 产品 Showcase（演出安排）
+
+> 以下产品均需在官网首页做"演出"展示，**Yaklang 与 Yakit 为必演项目**。
+
+### 🎤 必演一：Yaklang（语言全景演出）
+
+CDSL-YAK 是整个生态的灵魂，演出要回答三个问题：**这门语言是什么 / 它能做什么 / 为什么它比通用语言更适合做安全。**
+
+| 演出片段 | 素材建议 |
+| --- | --- |
+| **60 秒语言全景** | 【TODO 视频剪辑：复用首页现成素材 `https://oss-qn.yaklang.com/yak_quick_view_1.5.mp4`（Yak 全景视频），剪 60s 精华版】 |
+| **代码即能力** | 演示用 10 行 Yaklang 完成"扫描一个 C 段 + 检测一个 CVE + 反连回显"全流程； |
+| **热加载调试流量** | MITM 中右键一段流量 → 嵌入 Yaklang 脚本实时改包； |
+| **SyntaxFlow 一行查漏洞** | 用一条 SyntaxFlow 表达式从 SpringBoot 源码里捞出某个 SQL 注入 sink； |
+| **跨平台单二进制** | macOS / Linux / Windows / 国产化（统信 UOS、麒麟）一键安装。 |
+
+> 安装命令（演出 / 文档通用）：
+>
+> ```bash
+> # MacOS / Linux
+> bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)
+>
+> # Windows
+> powershell (new-object System.Net.WebClient).DownloadFile('https://oss-qn.yaklang.com/yak/latest/yak_windows_amd64.exe','yak_windows_amd64.exe') && yak_windows_amd64.exe install && del /f yak_windows_amd64.exe
+> ```
+
+### 🎤 必演二：Yakit（平台能力演出）
+
+Yakit 是 CDSL 的"最佳实践"演出，要让安全从业者 30 秒内相信"这就是 BurpSuite 的国产化替代"。
+
+| 演出片段 | 素材建议 |
+| --- | --- |
+| **MITM 交互式劫持** | 劫持 → History → Repeater / Intruder，操作流对标 BurpSuite；【TODO 配图：使用 `imgs/yakit-mitm.png`】 |
+| **MITM 被动扫描 GUI** | 劫持即扫描，无需额外配置；【TODO 视频剪辑：被动扫描实时发现漏洞 GIF】 |
+| **Web Fuzzer + Fuzztag** | 用 `{{int(1-100)}}` 这类 Fuzztag 语法做可视化模糊测试；【TODO 配图：`imgs/webfuzzer.png` + `imgs/fuzztag.png`】 |
+| **反连与协议复用** | 反弹 shell、内网穿透 bridge 模式；【TODO 配图：`imgs/reverse.png`】 |
+| **插件商店** | 一键安装社区插件，覆盖渗透全流程； |
+| **AI Agent（v1.4 新能力）** | 在 Yakit 内直接调度 AI 完成任务规划与执行。 |
+
+### 🎤 选演：IRify / Memfit AI
+
+| 产品 | 演出核心 | 素材建议 |
+| --- | --- | --- |
+| IRify | "用 SyntaxFlow 一行表达一个漏洞规则" + "SAST × AI 双引擎协同" | 【TODO 视频剪辑：导入一个真实 Java 项目，3 分钟扫出注入类漏洞的过程】 |
+| Memfit AI | "战略层规划 + 战术层执行"双引擎递归拆解一个复杂攻防任务 | 【TODO 视频剪辑：给 Memfit 一个模糊目标，展示它自动拆解 → 调用 Yaklang 工具 → 完成攻击的全过程】 |
+
+---
+
+## 📜 故事板：开源故事 Timeline
+
+> 以下时间线综合自 yaklang / yakit 两仓库的真实 git 历史，以及官网 Team 页的权威背书。
+> 标记 ⭐ 的是建议在官网 Timeline 页重点呈现的"大新闻"节点。
+
+### 🌱 起源：从"安全融合"理念到一门语言（2021 之前）
+
+- **理念萌芽**：核心团队达成共识——「**安全融合势在必行**」。与其继续做"再多一把瑞士军刀"，不如做一些**底层的安全融合、做一些基建**。
+- **学术支撑**：电子科技大学网络空间安全研究院（张小松教授团队）成为 YAK 架构和思想的策源地，承担核心团队培养。
+- **公司化运营**：四维创智（北京）科技发展有限公司，品牌名**万径安全**（2013 成立），使命"让世界更安全，让安全更简单"，以「**AI+YAK**」为企业核心战略。
+
+> 创始人寄语：
+> 「我希望他成为像 **Matlab** 一样的领域垂直语言，希望他成为『黑客编程』的代名词之一。」
+> 「**做难且正确的事。**」
+
+### 🚀 阶段一：Yakit 开源，国产化 BurpSuite 挑战者（2021）
+
+- **2021-10-12** ⭐ **Yakit 首次开源**——一次性导入完整源码（commit `c71c3a9e "Yakit Source Code"`），首日即具备 MITM、Web Fuzzer、Codec、端口扫描、插件等核心能力。
+- **2021-10-20** 首个公开 Tag **v1.0.8** 发布。
+- **2021-11-12** 首个稳定版 **v1.0.9** 正式发布（历经 beta2 ~ beta8 + patch1）。
+- **2021 Q4** 完成插件商店、网站结构树（crawler）、Linux x64 编译支持，CI 自动发布到 GitHub Release。
+
+### 🧱 阶段二：Yakit 成熟 + Yaklang 引擎开源（2022 ~ 2023 上半年）
+
+- **2022-08-19** Yakit 进入 **v1.1** 系列。
+- **2022 全年** 补齐反连服务器、Java 反序列化、企业版雏形（2022-10-22 首次企业版 CI）、Teamserver 双模式。
+- **2023-04-21** Yakit 进入 **v1.2** 系列。
+
+### 🎯 阶段三：Yaklang 核心开源元年（2023）
+
+- **2023-05-04** ⭐⭐ **Yaklang 核心仓库正式开源**——首提交 `47ab1423 "Init Commit for Yaklang Core"`，**首日即发布 `v1.2.0-sp6`**。开源第一天即带入 MITM / Crawlerx / Fuzz / Synscan / Chaosmaker / YakVM 等完整模块，CDSL 理念从第一天就是核心叙事。
+- **2023-05-11** 首个正式 patch 版本 **v1.2.1**。
+- **2023-07-28** SSA MVP 首次实现（`feat(SSA MVP) implement simple dataflow control`）——为日后 IRify 打下地基。
+- **2023-11-28** LSP 语言服务器首次落地（`feat(grpc): language server basic for yak runner`）。
+- **2023-12-14** ⭐ **SyntaxFlow 首次落地**（`syntaxflow ops`）——Yak 自研的漏洞特征建模 DSL 诞生。
+- **2023 全年** yaklang 仓库 3,105 次提交，yakit 仓库 1,875 次提交。
+
+### 🏆 阶段四：国家级荣誉 + 院士鉴定（2023 ~ 2025）
+
+- **2023** ⭐⭐⭐ **YAK 入选工信部信息通信领域十大科技进展**（国家级科技荣誉）。
+- **2024** ⭐⭐⭐ **YAK 教材《CDSL-YAK 网络安全领域编程语言—从入门到实践》正式出版**。
+- **2024 / 2025** ⭐⭐⭐ **连续两年，YAK 被九位院士鉴定为「国内外首创、国际先进、国内领先水平」，具有完全自主知识产权。**
+
+### ⚙️ 阶段五：编译器基础设施成熟（2024）
+
+- **2024-01-05** Yaklang 进入 **v1.3.0**。
+- **2024-03-14** AI 能力首次合入（`add glm` / `merge ai proj structure`）。
+- **2024-04-18** LSP 支持 Find Reference / Definition（IDE 级体验完善）。
+- **2024-04-23** SyntaxFlow 重构，进入生产可用阶段。
+- **2024-04-28** Cybertunnel（反向连接基础设施）首次出现。
+- **2024-06-21** ⭐ Yakit 衍生出 **ce（社区版）/ ee（企业版）双线发布**。
+- **2024 全年** yaklang 4,277 次提交、yakit 2,182 次提交（双仓库历史峰值）。
+
+### 🤖 阶段六：AI 元年（2025）
+
+- **2025-01-10** Yakit 进入 **v1.4 系列**，确立月度发布节奏。
+- **2025-02-10** MCP（Model Context Protocol）服务首次加入（`add mcp base`）。
+- **2025-03-12** ⭐ **Yakit AI-Agent 功能页面落地**（AI Agent 正式进入 Yakit 主线）。
+- **2025-03-27** ⭐ **IRify 正式命名**（`fix name sast to irify`），从 sast 模块独立。
+- **2025-05-07** 新版 Java 反编译器（JavaJive 的前身）进入 Yakit。
+- **2025-07-02 / 2025-08-12** ⭐ **AI Agent / aireact 框架成型**——Memfit AI 的技术底座。
+- **2025-09-26** Yakit 知识库（KnowledgeBase）上线。
+- **2025 全年** yaklang 4,342 次提交、yakit 1,982 次提交。
+
+### 🚀 阶段七：产品矩阵成型（2026）
+
+- **2026-05-29** ⭐ **Irify AI 代码审计**正式进入 Yakit（`Feature/irify/ai code audit new`）——IRify 升级为 SAST + AI 双引擎。
+- **2026-07-03 / 07-11** Yakit 最新系列 **v1.4.8** 发布，渲染端跨入 **v2.x**（最新 `v2.07.13-render`）。
+- **2026-07-13** Yaklang 最新 **v1.4.8-beta4** 发布，IM Bot 远程控制（`imcontrol`）模块上线。
+- **至今（2026-07）**：Yaklang 累计 14,000+ 提交 / 600+ tag；Yakit 累计 8,400+ 提交 / 343 tag / 51 贡献者 / 84 个功能模块。
+
+> 【TODO 配图：把上面 7 个阶段做成一条横向 timeline 视觉长图，每个阶段一张代表图 + 一个里程碑 tag】
+
+### 🤝 大新闻与活动素材（待补齐）
+
+> 以下是建议补充到 Timeline / 新闻墙的真实事件，**需要运营同学补充配图、链接、日期**。
+
+- 🏅 **2023 工信部信息通信领域十大科技进展** ——【TODO 配图：获奖证书 / 颁奖现场照片】
+- 📚 **2024 CDSL-YAK 教材出版** ——【TODO 配图：教材封面（已有 `static/img/team/teachingmaterials.png`）+ 新书发布会照片】
+- 🎖️ **2024 / 2025 九位院士鉴定** ——【TODO 配图：鉴定会现场照片 / 鉴定意见扫描件 / 九位院士名单】
+- 🎤 **Yak 线下交流 / Meetup** ——【TODO 配图：往届 Yak 用户见面会、技术沙龙、高校巡讲照片；TODO 视频剪辑：活动回顾短片】
+- 🚀 **大型发布会**（万径千机 / IRify / Memfit AI 发布）——【TODO 配图：发布会主视觉 + 现场照片；TODO 视频剪辑：发布会 high light】
+- 🏆 **张小松教授荣誉**：2020 第二届全国创新争先奖、2017 国家网络安全优秀人才奖、国家重点研发计划网络空间安全专项首席科学家 ——【TODO 配图：获奖证书】
+- 🌐 **生态合作**：能源、金融、运营商等多行业落地 ——【TODO 配图：行业落地案例（脱敏）】
+- 🎮 **社区活动**：KCon / 护网 / HackingClub / CTF 战队合作 ——【TODO 配图：大会展位、演讲照片】
+
+---
+
+## 💬 用户故事
+
+> 以下评价节选自官网首页"立即体验"区块的 20 条真实用户反馈（原文位于 `src/components/Home.tsx`）。完整版本待整理为独立"用户故事"专题页。
+
+| 用户 | 身份 / 背景 | 原话摘录 |
+| --- | --- | --- |
+| **ykc** | 长亭科技 | 「Yak 创造了足够的可能性，让我们可以在巨人的肩膀上发挥想象力。」 |
+| **P0m32Kun** | 安全从业者（2021 年底接触 Yak） | 「初次接触 Yak 是在 2021 年底……渐渐感受到了这是个有温度的团队……希望更多的安全从业者加入国产化的建设中。」 |
+| **国产大熊猫** | 生态共建贡献者 | 「Yakit 是一款优秀的国产 web 渗透工具……像一位战友陪伴在身边。」 |
+| **wooluo** | 安全从业者 | 「国产渗透中单兵作业工具……代替 BurpSuite 的不二首选。」 |
+| **Alex-null** | 青藤云安全 | 「Yak 是目前看到的国内最优秀的安全能力底座。」 |
+| **小米粥** | 安全从业者 | 「Yakit 确实是安全领域内最适用的语言……成为安全的『基座』。」 |
+| **李大壮** | Xiecat 团队 | 「成为安全领域的 Matlab。」 |
+| **key@OverSpace** | 安全从业者 | 「完成了某种意义上的『大一统』。」 |
+
+> 【TODO 配图：8 位代表性用户头像 + 身份徽章，做成"用户故事墙"】
+> 【TODO 内容：补充更多深度用户故事（企业落地案例、CTF 战队使用、高校教学案例），每篇 300~500 字】
+
+### 🌟 团队与共建者
+
+**核心团队**（[官网 Team 页](https://yaklang.com/team)）：
+- **v1ll4n / VillanCh**（项目作者，成都）· **sucre**（万径安全）· **奶权**（米斯特安全）· **f1ys0ar**（中科院博士）· **yuqi** · **small_j** · **z3r0ne** · **nonight**
+
+**生态共建杰出贡献成员**：
+- TimWhite · **ykc**（长亭科技）· **Alex-null**（青藤云安全）· 国产大熊猫 · **剑思庭**（工业安全红队 IRTeam 联合创始人）· HoAd · 斑马 · **shangzeng**（金融安全）· **李大壮**（Xiecat 团队）
+
+**特别顾问**：
+- **张小松**（电子科技大学长江学者特聘教授，2020 第二届全国创新争先奖、2017 国家网络安全优秀人才奖）
+- **phith0n**（Vulhub 创始人）· **翠花哥哥**（青藤）· **LuoyinFeng**（Roblox）· **HT.Zhang**（郑州大学）· **程昊**（首席法律顾问）
+
+**特别致谢**：
+- 🎓 电子科技大学网络空间安全研究院 —— YAK 架构和思想的策源地
+- 🏢 亚信安全 —— 企业安全与生态合作
+- 💚 **ProjectDiscovery** —— 无私的 MIT 开源精神，为 Yak 提供 nuclei 漏洞检测能力
+- 💚 **Vulhub** —— 无私的漏洞靶场基础设施提供者
+- 🏴 **CNSS** —— 优秀的 CTF 战队，为 Yak 安全能力构建提供灵感
+
+### 🤝 合作伙伴（Logo Wall）
+
+> 以下 20 家合作伙伴 Logo 已沉淀在 `src/components/CooperativePartner.tsx`，可直接用于官网合作伙伴墙。
+
+亚信安全 · 奇安信 · HackingClub · 米斯特安全 · 云众可信 · 58 · CTstack · E安全 · 嘶吼 · 四叶草安全 · 安全脉搏 · 智联 SRC · 度小满 · 贝壳 · 快手 · 小米 · 无糖信息 · 三叶草 · c4 安全团队
+
+> 【TODO 配图：合作伙伴 Logo 墙（横向滚动或网格布局）】
+
+---
+
+## 🌍 开源生态全景
+
+Yak Project 的开源生态不止上面四个产品，还包含以下协同子项目（数据源：`src/components/OpenSource.tsx`）：
+
+| 项目 | 一句话 | 站点 / 仓库 |
+| --- | --- | --- |
+| **IRify · SSA** | 基于 SSA 中间表示的静态代码分析与代码审计平台 | [ssa.to](https://ssa.to) · [yaklang/yaklang](https://github.com/yaklang/yaklang) |
+| **JavaJive** | 纯 Go 实现的 Java 工具箱：反编译 / 类解析 / 序列化 | [yaklang.io/javajive](https://yaklang.io/javajive/) · [yaklang/javajive](https://github.com/yaklang/javajive) |
+| **HackSkills** | 面向 AI Agent 的攻防技能知识库（101 个深度技能 / 14 个领域） | [skills.hackbenchmark.com](https://skills.hackbenchmark.com) · [yaklang/hack-skills](https://github.com/yaklang/hack-skills) |
+| **YakLab** | Web 漏洞靶场实战手册：Vulinbox 通关指南 | [/Yaklab/vulinbox/](/Yaklab/vulinbox/) · [yaklang/yaklang](https://github.com/yaklang/yaklang) |
+| **HackBenchmark** | 前沿 AI Agent 对真实 Web 漏洞的可复现评测基准 | [hackbenchmark.com](https://hackbenchmark.com) · [yaklang/hackbenchmark](https://github.com/yaklang/hackbenchmark) |
+| **Memfit AI** | 面向智能体系统的递归式双引擎混合架构 | [memfit.ai](https://memfit.ai) · [yaklang/yaklang/common/ai/aid](https://github.com/yaklang/yaklang/tree/main/common/ai/aid) |
+
+---
+
+## 🎨 品牌视觉规范
+
+供运营同学做配图、Banner、海报时统一参照。
+
+| 项目 | 数值 / 路径 |
+| --- | --- |
+| **品牌主色（蓝）** | `#3399dd`（衍生：dark `#238cd2` / darkest `#1b6da3` / light `#4aa5e1` / lightest `#79bce9`） |
+| **品牌强调色（橙）** | `#ff7d23` |
+| **Logo（矢量）** | `static/img/logo.svg` |
+| **Logo（位图）** | `static/img/logo.png` |
+| **页脚 Logo** | `static/img/footerLogo.svg` |
+| **favicon** | `static/img/favicon.ico` |
+| **开源子项目徽标** | `static/img/opensource/{ssa,javajive,hackskills,yaklab,hackbenchmark,memfit}.png` |
+| **教材封面** | `static/img/team/teachingmaterials.png` |
+| **万径安全品牌图** | `static/img/team/MegaVector.png` |
+
+**官方 Slogan 库**（按场景选用）：
+
+- 「**让世界更安全，让安全更简单**」—— 万径安全使命
+- 「**做难且正确的事**」—— 团队口号
+- 「**为网络安全而生的领域编程语言**」—— CDSL-YAK 主标
+- 「**网络安全领域的首个 DSL**」—— CDSL 定位
+- 「**可能是安全领域最先进的 DSL**」—— 技术对标
+- 「**Static-Single-Assignment Bringing Clarity to Code**」—— IRify 副标
+- 「**AI+YAK**」—— 万径安全核心战略
+
+---
+
+## 🛠️ 网站维护（给官网维护者）
+
+本仓库是基于 [Docusaurus 3](https://docusaurus.io/) 构建的多语言（`zh-CN` / `en`）官网，部署于 [yaklang.com](https://yaklang.com) / [yaklang.io](https://yaklang.io)。
+
+### 目录速览
+
+| 目录 | 内容 |
+| --- | --- |
+| `docs/` | Yak 编程语言文档（语言基础 + 内置库 + API + AI 编程） |
+| `products/` | Yakit 使用手册（chapter-1 ~ chapter-5 + legacy 旧版） |
+| `Yaklab/` | Vulinbox 漏洞靶场实战手册 |
+| `blog/` | 技术博客（200+ 篇） |
+| `team/` | 团队页源 md（intro / devtalk / contact） |
+| `src/pages/` | 顶级路由页（index / irify / opensource / team / cooperativePartner / download / enterpriseCollaboration） |
+| `src/components/` | React 组件（Home / Team / IRify / OpenSource / CooperativePartner / MainPageContent） |
+| `static/img/` | 所有品牌素材与产品截图 |
+
+### 关键素材文件（修改产品信息时优先查这里）
+
+1. `src/components/OpenSource.tsx` —— 开源生态项目结构化数据（产品矩阵）
+2. `src/components/Team.tsx` L403-407 —— 公司定位 + 三大权威奖项原句
+3. `src/components/Home.tsx` L1917-2263 —— 20 条用户评价
+4. `src/components/CooperativePartner.tsx` —— 合作伙伴 logo 清单
+5. `team/devtalk.md` —— 开源故事 / 初心
+6. `docs/intro.md` —— Yak 语言定位原文
+7. `products/intro.mdx` —— Yakit 定位原文
+8. `tailwind.config.js` + `src/css/custom.scss` —— 品牌色定义
+
+### 本地启动
+
+```bash
+# 安装依赖
+yarn install
+
+# 本地开发（默认 zh-CN）
+yarn start
+
+# 英文本地预览
+yarn start --locale en
+
+# 构建生产产物
+yarn build
+```
+
+### 常用入口链接
+
+- Yak 编程文档：[/docs/intro](https://yaklang.com/docs/intro)
+- Yakit 使用手册：[/products/intro](https://yaklang.com/products/intro)
+- 技术博客：[/blog](https://yaklang.com/blog)
+- 开源生态：[/opensource](https://yaklang.com/opensource)
+- 关于我们：[/team](https://yaklang.com/team)
+- 合作伙伴：[/cooperativePartner](https://yaklang.com/cooperativePartner)
+- 下载资源：[/download](https://yaklang.com/download)
+- 技术白皮书：[yakit-technical-white-paper.pdf](https://oss-qn.yaklang.com/yakit-technical-white-paper.pdf)
+
+---
+
+## 📄 License
+
+Yak Project 核心代码遵循 **GNU Affero General Public License v3 (AGPL-3.0)** —— 严格且具有传染性，提供网络服务的源代码必须开源。详见各仓库的 `LICENSE.md`。
+
+本官网仓库内容（文档、文案、配图）版权所有 © Yak Project。
+
+<footer>
+  Copyright © Yak Project · 京ICP备17047700号-3 · 京公网安备11010802048712号
+</footer>

--- a/components.json
+++ b/components.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/css/custom.scss",
+    "baseColor": "stone",
+    "cssVariables": false,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "registries": {
+    "@reactbits-starter": {
+      "url": "https://pro.reactbits.dev/api/r/starter",
+      "style": "new-york",
+      "headers": {
+        "Authorization": "Bearer ${REACTBITS_LICENSE_KEY}"
+      }
+    },
+    "@reactbits-pro": {
+      "url": "https://pro.reactbits.dev/api/r/pro",
+      "style": "new-york",
+      "headers": {
+        "Authorization": "Bearer ${REACTBITS_LICENSE_KEY}"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "@docusaurus/theme-common": "3.9.2",
     "@docusaurus/utils-common": "3.9.2",
     "@mdx-js/react": "^3.0.0",
+    "@paper-design/shaders-react": "^0.0.77",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@svgr/webpack": "^8.1.0",
     "ahooks": "^3.8.4",
     "animate.css": "^4.1.1",
@@ -34,6 +37,8 @@
     "docusaurus-plugin-sass": "^0.2.6",
     "fflate": "^0.8.3",
     "i18next": "^23.16.8",
+    "lucide-react": "^1.24.0",
+    "motion": "^12.42.2",
     "postcss": "^8.4.49",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",
@@ -42,7 +47,9 @@
     "react-lazyload": "^3.2.1",
     "sass": "^1.83.4",
     "swiper": "^11.2.1",
-    "tailwindcss": "^3.4.17"
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^3.4.17",
+    "three": "^0.185.1"
   },
   "browserslist": {
     "production": [
@@ -63,6 +70,7 @@
     "@docusaurus/module-type-aliases": "3.9.2",
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
+    "@types/three": "^0.185.1",
     "cross-env": "^7.0.3",
     "typescript": "~5.6.2"
   },

--- a/src/components/blocks/download-8.tsx
+++ b/src/components/blocks/download-8.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ArrowUpRight, Check, Copy, PackageCheck, ShieldCheck, Terminal } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion, type Variants } from "motion/react";
+
+const container: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08, delayChildren: 0.05 } },
+};
+
+const item: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+const outputList: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.07 } },
+};
+
+const outputLine: Variants = {
+  hidden: { opacity: 0, y: 6 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+const installers = [
+  {
+    id: "macos",
+    label: "macOS",
+    command: "brew install orbit-cli",
+    output: [
+      "Downloading orbit 3.12.0 · darwin-arm64",
+      "Signature verified · minisign",
+      "Installed to /opt/homebrew/bin/orbit",
+    ],
+  },
+  {
+    id: "linux",
+    label: "Linux",
+    command: "curl -fsSL https://get.orbit.dev | sh",
+    output: [
+      "Detecting platform · linux-x86_64",
+      "Signature verified · minisign",
+      "Installed to /usr/local/bin/orbit",
+    ],
+  },
+  {
+    id: "windows",
+    label: "Windows",
+    command: "winget install Orbit.CLI",
+    output: [
+      "Resolving package · Orbit.CLI 3.12.0",
+      "Authenticode signature verified",
+      "Installed to %LOCALAPPDATA%\\Orbit\\orbit.exe",
+    ],
+  },
+];
+
+const guarantees = [
+  {
+    icon: ShieldCheck,
+    title: "Signed binaries",
+    text: "Every artifact ships with a minisign signature and checksums published on the releases page.",
+  },
+  {
+    icon: Terminal,
+    title: "Shell completions",
+    text: "Completions for bash, zsh, fish, and PowerShell install automatically on first run.",
+  },
+  {
+    icon: PackageCheck,
+    title: "Pinned releases",
+    text: "Lock your team to a known version and roll forward on your own schedule.",
+  },
+];
+
+export function Download8() {
+  const [activeId, setActiveId] = useState(installers[0].id);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const reduceMotion = useReducedMotion();
+
+  const active = installers.find((installer) => installer.id === activeId) ?? installers[0];
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const copyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText(active.command);
+      setCopied(true);
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <section className="w-full bg-white px-4 py-16 dark:bg-neutral-950 sm:px-6 sm:py-20 lg:px-8 lg:py-24">
+      <motion.div
+        variants={container}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, margin: "-80px" }}
+        className="mx-auto flex w-full max-w-[1400px] flex-col items-center"
+      >
+        <motion.h2
+          variants={item}
+          className="max-w-3xl text-center text-3xl font-medium tracking-tight text-neutral-900 text-balance dark:text-white sm:text-4xl md:text-5xl lg:text-6xl"
+        >
+          Install the command center in one line.
+        </motion.h2>
+
+        <motion.p
+          variants={item}
+          className="mt-6 max-w-xl text-center text-base leading-relaxed text-neutral-600 dark:text-neutral-400 sm:text-lg"
+        >
+          Releases, environment checks, and team scripts — run from the terminal your engineers already live in.
+        </motion.p>
+
+        <motion.div variants={item} className="mt-12 w-full max-w-3xl">
+          <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-neutral-950 shadow-xl shadow-neutral-900/10 dark:border-neutral-800 dark:shadow-black/40">
+            <div className="flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3 sm:px-5">
+              <div className="flex items-center gap-3">
+                <span className="flex gap-1.5" aria-hidden="true">
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                </span>
+                <span className="hidden font-mono text-xs text-neutral-500 sm:inline">orbit · install</span>
+              </div>
+              <div className="flex rounded-full border border-white/10 bg-white/5 p-1">
+                {installers.map((installer) => (
+                  <button
+                    key={installer.id}
+                    type="button"
+                    onClick={() => setActiveId(installer.id)}
+                    aria-pressed={activeId === installer.id}
+                    className="relative cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                  >
+                    {activeId === installer.id && (
+                      <motion.span
+                        layoutId="orbit-active-tab"
+                        style={{ borderRadius: 9999 }}
+                        transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                        className="absolute inset-0 bg-white"
+                      />
+                    )}
+                    <span
+                      className={`relative z-10 transition-colors ${
+                        activeId === installer.id ? "text-neutral-900" : "text-neutral-400 hover:text-white"
+                      }`}
+                    >
+                      {installer.label}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="px-5 py-6 sm:px-7 sm:py-7">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <p className="min-w-0 break-words font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
+                  <span className="select-none text-neutral-500">$ </span>
+                  {active.command}
+                  {reduceMotion ? (
+                    <span
+                      aria-hidden="true"
+                      className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
+                    />
+                  ) : (
+                    <motion.span
+                      aria-hidden="true"
+                      className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
+                      animate={{ opacity: [1, 1, 0, 0] }}
+                      transition={{ duration: 1.1, repeat: Infinity, times: [0, 0.5, 0.5, 1], ease: "linear" }}
+                    />
+                  )}
+                </p>
+
+                <button
+                  type="button"
+                  onClick={copyCommand}
+                  className="inline-flex h-9 min-w-[104px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 px-4 text-xs font-medium text-neutral-300 transition-colors hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                >
+                  <AnimatePresence mode="wait" initial={false}>
+                    {copied ? (
+                      <motion.span
+                        key="copied"
+                        initial={{ opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -4 }}
+                        transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                        className="inline-flex items-center gap-2"
+                      >
+                        <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                        Copied
+                      </motion.span>
+                    ) : (
+                      <motion.span
+                        key="copy"
+                        initial={{ opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -4 }}
+                        transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                        className="inline-flex items-center gap-2"
+                      >
+                        <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                        Copy
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </button>
+              </div>
+
+              <div className="mt-6 border-t border-white/10 pt-5">
+                <div className="min-h-[132px] sm:min-h-[120px]">
+                  <AnimatePresence mode="wait" initial={false}>
+                    <motion.ul
+                      key={active.id}
+                      variants={outputList}
+                      initial="hidden"
+                      animate="visible"
+                      exit={{ opacity: 0, transition: { duration: 0.15 } }}
+                      className="space-y-2.5 font-mono text-[13px]"
+                    >
+                      {active.output.map((line) => (
+                        <motion.li key={line} variants={outputLine} className="flex items-center gap-2.5 text-neutral-400">
+                          <Check className="h-3.5 w-3.5 shrink-0 text-emerald-400" aria-hidden="true" />
+                          <span className="min-w-0 break-words">{line}</span>
+                        </motion.li>
+                      ))}
+                      <motion.li variants={outputLine} className="pt-1.5 text-neutral-100">
+                        → run <span className="rounded-md bg-white/10 px-1.5 py-0.5">orbit init</span> to link your
+                        workspace
+                      </motion.li>
+                    </motion.ul>
+                  </AnimatePresence>
+                </div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        <motion.div
+          variants={item}
+          className="mt-5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs text-neutral-500 dark:text-neutral-500"
+        >
+          <span>v3.12.0</span>
+          <span aria-hidden="true">·</span>
+          <span>sha256 + minisign</span>
+          <span aria-hidden="true">·</span>
+          <span>macos / linux / windows</span>
+        </motion.div>
+
+        <motion.a
+          variants={item}
+          href="#"
+          className="mt-8 inline-flex cursor-pointer items-center gap-1.5 rounded-sm text-sm font-medium text-neutral-900 transition-colors hover:text-neutral-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-900/20 dark:text-white dark:hover:text-neutral-300 dark:focus-visible:ring-white/30"
+        >
+          Prefer signed binaries? Direct downloads
+          <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+        </motion.a>
+
+        <div className="mt-16 grid w-full max-w-4xl grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8">
+          {guarantees.map((point) => (
+            <motion.div key={point.title} variants={item}>
+              <point.icon className="h-5 w-5 text-neutral-900 dark:text-white" aria-hidden="true" />
+              <h3 className="mt-4 text-sm font-semibold text-neutral-900 dark:text-white">{point.title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">{point.text}</p>
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/homepage/DownloadBlock.tsx
+++ b/src/components/homepage/DownloadBlock.tsx
@@ -48,6 +48,7 @@ type PlatformId = "macos" | "windows" | "linux" | "web" | "releases";
 
 type DownloadAsset = {
   label: string;
+  description?: string;
   file: string;
 };
 
@@ -206,11 +207,23 @@ const PRODUCTS: Record<ProductKey, ProductSpec> = {
 };
 
 const LEGACY_FILES: DownloadAsset[] = [
-  { label: "Windows 7", file: "windows-legacy-amd64.exe" },
-  { label: "Linux x86_64", file: "linux-legacy-amd64.AppImage" },
-  { label: "Linux ARM64", file: "linux-legacy-arm64.AppImage" },
-  { label: "macOS Intel", file: "darwin-legacy-x64.dmg" },
-  { label: "macOS Apple Silicon", file: "darwin-legacy-arm64.dmg" },
+  { label: "Windows", description: "适用于 Windows 7", file: "windows-legacy-amd64.exe" },
+  {
+    label: "Linux x86_64",
+    description: "适用于统信 UOS、麒麟等国产系统，请确认设备架构",
+    file: "linux-legacy-amd64.AppImage",
+  },
+  {
+    label: "Linux ARM64",
+    description: "适用于统信 UOS、麒麟等国产系统，请确认设备架构",
+    file: "linux-legacy-arm64.AppImage",
+  },
+  { label: "macOS Intel", description: "适用于旧版 Intel Mac 系统", file: "darwin-legacy-x64.dmg" },
+  {
+    label: "macOS Apple Silicon",
+    description: "适用于需要兼容构建的 Apple Silicon Mac",
+    file: "darwin-legacy-arm64.dmg",
+  },
 ];
 
 const productKeys = Object.keys(PRODUCTS) as ProductKey[];
@@ -382,7 +395,7 @@ export default function DownloadBlock() {
   };
 
   return (
-    <section className="w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-24">
+    <section id="downloads" className="w-full scroll-mt-[60px] px-4 py-14 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
       <motion.div
         variants={container}
         initial="hidden"
@@ -399,63 +412,101 @@ export default function DownloadBlock() {
           {product.title}
         </motion.h2>
 
-        <motion.p variants={item} className="mt-6 max-w-xl text-center text-base leading-relaxed sm:text-lg" style={{ color: "var(--hp-ink-55)" }}>
+        <motion.p variants={item} className="mt-4 max-w-xl text-center text-base leading-relaxed sm:text-lg" style={{ color: "var(--hp-ink-55)" }}>
           {product.description}
         </motion.p>
 
-        <motion.div variants={item} className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 border-b" style={{ borderColor: "var(--hp-line)" }}>
-          {productKeys.map((key) => (
-            <button
-              key={key}
-              type="button"
-              onClick={() => selectProduct(key)}
-              aria-pressed={activeProduct === key}
-              className="hp-mono relative cursor-pointer border-0 bg-transparent px-0 pb-3 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2"
-              style={{ color: activeProduct === key ? "var(--hp-orange)" : "var(--hp-ink-55)" }}
-            >
-              {key}
-              {activeProduct === key && <motion.span layoutId="product-active-tab" className="absolute inset-x-0 -bottom-px h-0.5" style={{ background: "var(--hp-orange)" }} />}
-            </button>
-          ))}
+        <motion.div
+          variants={item}
+          role="tablist"
+          aria-label="选择 Yak Project 产品"
+          className="mt-6 grid w-full max-w-xl grid-cols-2 gap-1 rounded-xl border p-1 sm:grid-cols-4"
+          style={{ borderColor: "var(--hp-line)", background: "rgba(33, 26, 18, 0.035)" }}
+        >
+          {productKeys.map((key) => {
+            const selected = activeProduct === key;
+
+            return (
+              <button
+                key={key}
+                id={`product-tab-${key.toLowerCase()}`}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                aria-controls="download-product-panel"
+                onClick={() => selectProduct(key)}
+                className="hp-mono relative min-h-10 cursor-pointer rounded-lg border-0 px-4 py-2 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2"
+                style={{ color: selected ? "#fff" : "var(--hp-ink)", background: "transparent" }}
+              >
+                {selected && (
+                  <motion.span
+                    layoutId="product-active-tab"
+                    className="absolute inset-0 rounded-lg shadow-sm"
+                    style={{ background: "var(--hp-orange)" }}
+                    transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+                  />
+                )}
+                <span className={`relative z-10 ${selected ? "" : "opacity-65 transition-opacity hover:opacity-100"}`}>{key}</span>
+              </button>
+            );
+          })}
         </motion.div>
 
-        <motion.div variants={item} className="mt-10 w-full max-w-3xl">
+        <motion.div
+          id="download-product-panel"
+          role="tabpanel"
+          aria-labelledby={`product-tab-${activeProduct.toLowerCase()}`}
+          variants={item}
+          className="mt-7 w-full max-w-3xl"
+        >
           <div className="overflow-hidden rounded-2xl border shadow-xl" style={terminalStyle}>
-            <div className="flex flex-col gap-3 border-b border-white/10 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+            <div className="flex flex-col gap-2.5 border-b border-white/10 px-4 py-2.5 sm:flex-row sm:items-center sm:justify-between sm:px-5">
               <div className="flex min-w-0 items-center gap-3">
                 <span className="flex shrink-0 gap-1.5" aria-hidden="true">
-                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
-                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/25" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/25" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/25" />
                 </span>
-                <span className="truncate font-mono text-xs text-neutral-500">{activeProduct.toLowerCase()} · install</span>
+                <span className="truncate font-mono text-xs text-neutral-400">{activeProduct.toLowerCase()} · install</span>
               </div>
-              <div className="flex max-w-full overflow-x-auto rounded-full border border-white/10 bg-white/5 p-1">
-                {product.platforms.map((platform) => (
-                  <button
-                    key={platform.id}
-                    type="button"
-                    onClick={() => setActiveId(platform.id)}
-                    aria-pressed={active.id === platform.id}
-                    className="relative shrink-0 cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
-                  >
-                    {active.id === platform.id && (
-                      <motion.span
-                        layoutId="download-active-platform"
-                        style={{ borderRadius: 9999 }}
-                        transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
-                        className="absolute inset-0 bg-white"
-                      />
-                    )}
-                    <span className={`relative z-10 transition-colors ${active.id === platform.id ? "text-neutral-900" : "text-neutral-400 hover:text-white"}`}>
-                      {platform.label}
-                    </span>
-                  </button>
-                ))}
+              <div role="tablist" aria-label="选择操作系统" className="flex max-w-full overflow-x-auto rounded-full border border-white/20 bg-white/10 p-1 shadow-inner">
+                {product.platforms.map((platform) => {
+                  const selected = active.id === platform.id;
+
+                  return (
+                    <button
+                      key={platform.id}
+                      id={`platform-tab-${activeProduct.toLowerCase()}-${platform.id}`}
+                      type="button"
+                      role="tab"
+                      aria-selected={selected}
+                      aria-controls="platform-download-panel"
+                      onClick={() => setActiveId(platform.id)}
+                      className={`relative min-h-8 shrink-0 cursor-pointer rounded-full border-0 px-3.5 py-1.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                        selected ? "" : "bg-transparent text-neutral-300 hover:bg-white/10 hover:text-white"
+                      }`}
+                    >
+                      {selected && (
+                        <motion.span
+                          layoutId="download-active-platform"
+                          style={{ borderRadius: 9999 }}
+                          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                          className="absolute inset-0 bg-white shadow-sm"
+                        />
+                      )}
+                      <span className={`relative z-10 ${selected ? "text-neutral-900" : ""}`}>{platform.label}</span>
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
-            <div className="px-5 py-6 sm:px-7 sm:py-7">
+            <div
+              id="platform-download-panel"
+              role="tabpanel"
+              aria-labelledby={`platform-tab-${activeProduct.toLowerCase()}-${active.id}`}
+              className="px-5 py-5 sm:px-6 sm:py-5"
+            >
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                 <p className="min-w-0 break-words font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
                   <span className="select-none text-neutral-500">$ </span>
@@ -475,8 +526,8 @@ export default function DownloadBlock() {
                 {renderAction()}
               </div>
 
-              <div className="mt-6 border-t border-white/10 pt-5">
-                <div className="min-h-[132px] sm:min-h-[120px]">
+              <div className="mt-4 border-t border-white/10 pt-4">
+                <div className="min-h-[104px] sm:min-h-[96px]">
                   <AnimatePresence mode="wait" initial={false}>
                     <motion.ul
                       key={`${activeProduct}-${active.id}`}
@@ -484,7 +535,7 @@ export default function DownloadBlock() {
                       initial="hidden"
                       animate="visible"
                       exit={{ opacity: 0, transition: { duration: 0.15 } }}
-                      className="space-y-2.5 font-mono text-[13px]"
+                      className="space-y-2 font-mono text-[13px]"
                     >
                       {active.output.map((line) => (
                         <motion.li key={line} variants={outputLine} className="flex items-center gap-2.5 text-neutral-400">
@@ -503,7 +554,7 @@ export default function DownloadBlock() {
           </div>
         </motion.div>
 
-        <motion.div variants={item} className="mt-5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs" style={{ color: "var(--hp-ink-55)" }}>
+        <motion.div variants={item} className="mt-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs" style={{ color: "var(--hp-ink-55)" }}>
           <span>{activeProduct === "Yakit" ? `v${version || "latest"}` : activeProduct}</span>
           <span aria-hidden="true">·</span>
           <span>{product.platforms.map((platform) => platform.label).join(" / ")}</span>
@@ -513,38 +564,86 @@ export default function DownloadBlock() {
 
         {activeProduct === "Yakit" ? (
           <>
-            <motion.button
-              variants={item}
-              type="button"
-              onClick={() => setLegacyOpen((open) => !open)}
-              aria-expanded={legacyOpen}
-              className="mt-8 inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent text-sm font-medium transition-colors hover:opacity-60 focus-visible:outline-none focus-visible:ring-2"
-              style={{ color: "var(--hp-ink)" }}
-            >
-              旧系统兼容版本
-              <ChevronDown className={`h-4 w-4 transition-transform ${legacyOpen ? "rotate-180" : ""}`} aria-hidden="true" />
-            </motion.button>
+            <motion.div variants={item} className="mt-6 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
+              <button
+                type="button"
+                onClick={() => setLegacyOpen((open) => !open)}
+                aria-expanded={legacyOpen}
+                aria-controls="legacy-downloads"
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border-0 bg-transparent p-1 font-medium transition-colors hover:text-[var(--hp-orange)] focus-visible:outline-none focus-visible:ring-2"
+                style={{ color: "var(--hp-ink)" }}
+              >
+                需要 Windows 7、旧版 macOS 或国产 Linux？下载旧系统兼容版本
+                <ChevronDown className={`h-4 w-4 shrink-0 transition-transform ${legacyOpen ? "rotate-180" : ""}`} aria-hidden="true" />
+              </button>
+              <span aria-hidden="true" style={{ color: "var(--hp-line)" }}>
+                ·
+              </span>
+              <a
+                href={product.installUrl}
+                className="inline-flex items-center gap-1 font-medium transition-colors hover:text-[var(--hp-orange)] focus-visible:outline-none focus-visible:ring-2"
+                style={{ color: "var(--hp-ink)" }}
+              >
+                安装说明
+                <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </motion.div>
             <AnimatePresence initial={false}>
               {legacyOpen && (
                 <motion.div
+                  id="legacy-downloads"
                   initial={{ height: 0, opacity: 0 }}
                   animate={{ height: "auto", opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
                   className="w-full max-w-3xl overflow-hidden"
                 >
-                  <div className="mt-5 flex flex-wrap justify-center gap-x-5 gap-y-3 border-t pt-5" style={{ borderColor: "var(--hp-line)" }}>
-                    {LEGACY_FILES.map((asset) =>
-                      version ? (
-                        <a key={asset.file} href={getYakitUrl(version, asset.file)} className="inline-flex items-center gap-1.5 text-xs font-medium hover:opacity-60" style={{ color: "var(--hp-ink)" }}>
-                          <Download className="h-3.5 w-3.5" aria-hidden="true" />
-                          {asset.label}
-                        </a>
-                      ) : (
-                        <span key={asset.file} className="text-xs" style={{ color: "var(--hp-ink-55)" }}>
-                          {asset.label}
-                        </span>
-                      ),
-                    )}
+                  <div className="mt-5 overflow-hidden rounded-xl border" style={{ borderColor: "var(--hp-line)", background: "rgba(255, 255, 255, 0.38)" }}>
+                    <div className="border-b px-4 py-3 sm:px-5" style={{ borderColor: "var(--hp-line)" }}>
+                      <p className="text-sm font-semibold" style={{ color: "var(--hp-ink)" }}>
+                        旧系统兼容安装包
+                      </p>
+                      <p className="mt-1 text-xs leading-relaxed" style={{ color: "var(--hp-ink-55)" }}>
+                        仅在最新版无法运行时使用。Linux 用户下载前请确认设备是 x86_64 还是 ARM64 架构。
+                      </p>
+                    </div>
+                    <div className="grid sm:grid-cols-2">
+                      {LEGACY_FILES.map((asset, index) => {
+                        const content = (
+                          <>
+                            <span className="min-w-0">
+                              <span className="block text-sm font-semibold" style={{ color: "var(--hp-ink)" }}>
+                                {asset.label}
+                              </span>
+                              <span className="mt-1 block text-xs leading-relaxed" style={{ color: "var(--hp-ink-55)" }}>
+                                {asset.description}
+                                {version ? ` · v${version}` : ""}
+                              </span>
+                            </span>
+                            <span
+                              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white transition-transform group-hover:scale-105"
+                              style={{ background: "var(--hp-orange)" }}
+                            >
+                              <Download className="h-4 w-4" aria-hidden="true" />
+                            </span>
+                          </>
+                        );
+                        const rowClass = `group flex min-h-[76px] items-center justify-between gap-4 border-b px-4 py-3 text-left transition-colors hover:bg-black/[0.035] sm:px-5 ${
+                          index % 2 === 0 ? "sm:border-r" : ""
+                        }`;
+                        const rowStyle = { borderColor: "var(--hp-line)" };
+
+                        return version ? (
+                          <a key={asset.file} href={getYakitUrl(version, asset.file)} className={rowClass} style={rowStyle}>
+                            {content}
+                          </a>
+                        ) : (
+                          <div key={asset.file} className={rowClass} style={rowStyle} aria-disabled="true">
+                            {content}
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
                 </motion.div>
               )}
@@ -556,7 +655,7 @@ export default function DownloadBlock() {
             href={product.installUrl}
             target={product.installUrl.startsWith("http") ? "_blank" : undefined}
             rel={product.installUrl.startsWith("http") ? "noreferrer" : undefined}
-            className="mt-8 inline-flex items-center gap-1.5 text-sm font-medium transition-colors hover:opacity-60 focus-visible:outline-none focus-visible:ring-2"
+            className="mt-6 inline-flex items-center gap-1.5 text-sm font-medium transition-colors hover:text-[var(--hp-orange)] focus-visible:outline-none focus-visible:ring-2"
             style={{ color: "var(--hp-ink)" }}
           >
             查看完整说明
@@ -564,7 +663,7 @@ export default function DownloadBlock() {
           </motion.a>
         )}
 
-        <div className="mt-16 grid w-full max-w-4xl grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8">
+        <div className="mt-12 grid w-full max-w-4xl grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8">
           {product.guarantees.map((guarantee) => (
             <GuaranteeItem key={`${activeProduct}-${guarantee.title}`} guarantee={guarantee} />
           ))}

--- a/src/components/homepage/DownloadBlock.tsx
+++ b/src/components/homepage/DownloadBlock.tsx
@@ -1,8 +1,6 @@
-// @ts-nocheck
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import axios from "axios";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import {
   ArrowUpRight,
   Check,
@@ -10,11 +8,10 @@ import {
   Copy,
   Download,
   ExternalLink,
-  Monitor,
-  MonitorSmartphone,
   PackageCheck,
   ShieldCheck,
   Terminal,
+  type LucideIcon,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion, type Variants } from "motion/react";
 
@@ -47,283 +44,240 @@ const outputLine: Variants = {
 };
 
 type ProductKey = "Yakit" | "Yaklang" | "IRify" | "Memfit";
+type PlatformId = "macos" | "windows" | "linux" | "web" | "releases";
 
-interface PlatformSpec {
-  id: string;
+type DownloadAsset = {
   label: string;
-  command?: string;
-  output?: string[];
-  file?: string;
-  subFile?: string;
-  href?: string;
-  external?: boolean;
-}
+  file: string;
+};
 
-interface ProductSpec {
-  tag: string;
+type PlatformSpec = {
+  id: PlatformId;
+  label: string;
+  prompt: string;
+  output: string[];
+  result: string;
+  command?: string;
+  href?: string;
+  assets?: DownloadAsset[];
+};
+
+type Guarantee = {
+  icon: LucideIcon;
   title: string;
-  desc: string;
+  text: string;
+};
+
+type ProductSpec = {
+  title: string;
+  description: string;
   installUrl: string;
   platforms: PlatformSpec[];
-  guarantees?: { icon: React.ComponentType<{ className?: string; style?: React.CSSProperties; "aria-hidden"?: boolean }>; title: string; text: string }[];
-}
+  guarantees: Guarantee[];
+};
 
 const PRODUCTS: Record<ProductKey, ProductSpec> = {
   Yakit: {
-    tag: "下载",
-    title: "YAK IDE (Yakit)",
-    desc: "由 Yaklang 驱动的交互式网络安全测试平台。安装 Yakit 即获得 Yak 语言运行环境与全部图形化能力。",
+    title: "安装 Yakit，开始使用 Yak Project。",
+    description: "选择你的系统，直接获取包含 Yaklang 引擎的最新版桌面客户端。",
     installUrl: "/products/legacy/download_and_install",
     platforms: [
       {
         id: "macos",
         label: "macOS",
-        file: "darwin-x64.dmg",
-        subFile: "darwin-arm64.dmg",
-        output: [
-          "下载 Yakit 最新版 · macOS",
-          "同时支持 Intel 与 Apple Silicon 芯片",
-          "安装后自动集成 Yak 语言运行环境",
+        prompt: "download yakit --platform macos",
+        assets: [
+          { label: "Apple Silicon", file: "darwin-arm64.dmg" },
+          { label: "Intel", file: "darwin-x64.dmg" },
         ],
+        output: ["准备 Yakit 最新稳定版 · macOS", "提供 Apple Silicon 与 Intel 安装包", "Yakit 已内置 Yaklang 运行环境"],
+        result: "下载后打开 DMG，将 Yakit 拖入 Applications",
       },
       {
         id: "windows",
         label: "Windows",
-        file: "windows-amd64.exe",
-        output: [
-          "下载 Yakit 最新版 · Windows x86_64",
-          "支持 Windows 10 / 11",
-          "安装后自动集成 Yak 语言运行环境",
-        ],
+        prompt: "download yakit --platform windows",
+        assets: [{ label: "x86_64", file: "windows-amd64.exe" }],
+        output: ["准备 Yakit 最新稳定版 · Windows x86_64", "支持 Windows 10 / 11", "Yakit 已内置 Yaklang 运行环境"],
+        result: "运行安装程序并按向导完成安装",
       },
       {
         id: "linux",
         label: "Linux",
-        file: "linux-amd64.AppImage",
-        subFile: "linux-arm64.AppImage",
-        output: [
-          "下载 Yakit 最新版 · Linux",
-          "支持 x86_64 与 ARM64 架构",
-          "兼容统信 UOS、麒麟等国产系统",
+        prompt: "download yakit --platform linux",
+        assets: [
+          { label: "x86_64", file: "linux-amd64.AppImage" },
+          { label: "ARM64", file: "linux-arm64.AppImage" },
         ],
+        output: ["准备 Yakit 最新稳定版 · Linux", "提供 x86_64 与 ARM64 AppImage", "兼容统信 UOS、麒麟等国产系统"],
+        result: "赋予 AppImage 执行权限后即可启动",
       },
     ],
     guarantees: [
-      {
-        icon: ShieldCheck,
-        title: "持续更新",
-        text: "Yakit 每月发布新版本，自动检测并提醒升级，保证安全能力与时俱进。",
-      },
-      {
-        icon: Terminal,
-        title: "内置 Yak 引擎",
-        text: "安装 Yakit 即自动配置 Yak 语言运行环境，无需单独安装语言二进制。",
-      },
-      {
-        icon: PackageCheck,
-        title: "跨平台一致",
-        text: "macOS / Windows / Linux 三端统一界面与能力，团队协同无壁垒。",
-      },
+      { icon: ShieldCheck, title: "持续更新", text: "稳定发布安全能力与引擎更新，客户端会自动检测可用的新版本。" },
+      { icon: Terminal, title: "内置 Yak 引擎", text: "安装 Yakit 即可获得完整 Yaklang 运行环境，无需额外配置。" },
+      { icon: PackageCheck, title: "跨平台一致", text: "macOS、Windows 与 Linux 使用统一界面和能力体系。" },
     ],
   },
   Yaklang: {
-    tag: "命令行",
-    title: "Yaklang 语言环境",
-    desc: "面向网络安全的 CDSL 领域编程语言。一行命令完成安装，支持 macOS / Linux / Windows。",
+    title: "一行命令，安装 Yaklang。",
+    description: "面向网络安全的 CDSL 编程语言，可独立用于终端、自动化与 CI 环境。",
     installUrl: "/docs/startup",
     platforms: [
       {
         id: "macos",
-        label: "macOS / Linux",
+        label: "macOS",
+        prompt: "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)",
         command: "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)",
-        output: [
-          "自动检测操作系统与架构",
-          "下载并安装最新 Yak 二进制",
-          "完成环境变量配置",
-        ],
+        output: ["自动检测 macOS 与处理器架构", "下载最新 Yak 二进制", "完成命令行环境配置"],
+        result: "运行 yak version 验证安装",
+      },
+      {
+        id: "linux",
+        label: "Linux",
+        prompt: "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)",
+        command: "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)",
+        output: ["自动检测 Linux 发行版与架构", "下载最新 Yak 二进制", "安装到系统命令路径"],
+        result: "运行 yak version 验证安装",
       },
       {
         id: "windows",
         label: "Windows",
+        prompt: "yak.exe install",
         command: "powershell (new-object System.Net.WebClient).DownloadFile('https://oss-qn.yaklang.com/yak/latest/yak_windows_amd64.exe','yak.exe'); yak.exe install",
-        output: [
-          "下载 Windows 版 Yak 安装器",
-          "自动完成安装与环境配置",
-          "命令行输入 yak 即可使用",
-        ],
+        output: ["下载 Windows 版 Yak 安装器", "完成二进制安装与环境配置", "注册 yak 命令"],
+        result: "重新打开终端并运行 yak version",
       },
       {
-        id: "linux",
-        label: "GitHub Releases",
+        id: "releases",
+        label: "Releases",
+        prompt: "open github.com/yaklang/yaklang/releases",
         href: "https://github.com/yaklang/yaklang/releases",
-        external: true,
-        output: [
-          "所有预编译二进制资产",
-          "包含各平台历史版本",
-          "适合 CI / 容器 / 离线部署",
-        ],
+        output: ["浏览全部预编译二进制", "获取历史版本与发布说明", "适合 CI、容器与离线部署"],
+        result: "选择对应系统与架构的发布资产",
       },
     ],
     guarantees: [
-      {
-        icon: Terminal,
-        title: "一行安装",
-        text: "macOS 与 Linux 只需一条 curl 命令即可将 Yak 安装到 PATH。",
-      },
-      {
-        icon: ShieldCheck,
-        title: "完全开源",
-        text: "Yaklang 核心遵循 AGPL-3.0 开源，源码托管于 GitHub，接受社区共建。",
-      },
-      {
-        icon: PackageCheck,
-        title: "跨平台",
-        text: "支持 macOS、Linux、Windows 及统信 UOS、麒麟等国产化系统。",
-      },
+      { icon: Terminal, title: "一行安装", text: "安装脚本自动识别平台与架构，并完成命令行环境配置。" },
+      { icon: ShieldCheck, title: "完全开源", text: "Yaklang 核心遵循 AGPL-3.0，源码与发行资产公开可查。" },
+      { icon: PackageCheck, title: "可独立部署", text: "适用于本地终端、自动化任务、容器与持续集成环境。" },
     ],
   },
   IRify: {
-    tag: "在线服务",
-    title: "IRify 代码审计平台",
-    desc: "兼具 SAST 与 AI 双引擎的代码安全分析系统。支持多语言源码建模、数据流分析与漏洞挖掘。",
+    title: "进入 IRify，审计真实代码。",
+    description: "基于 SSA IR 的多语言代码安全分析平台，结合 SAST 与 AI 双引擎。",
     installUrl: "https://ssa.to",
     platforms: [
       {
-        id: "linux",
-        label: "在线使用",
+        id: "web",
+        label: "Web",
+        prompt: "open https://ssa.to",
         href: "https://ssa.to",
-        external: true,
-        output: [
-          "基于 SSA IR 的多语言代码分析",
-          "SyntaxFlow 一行表达漏洞规则",
-          "SAST + AI 双引擎协同审计",
-        ],
+        output: ["打开 IRify 在线代码审计平台", "使用 SyntaxFlow 描述漏洞模式", "通过 SAST + AI 双引擎分析代码"],
+        result: "创建项目并导入待审计代码",
       },
     ],
     guarantees: [
-      {
-        icon: ShieldCheck,
-        title: "多语言支持",
-        text: "深度支持 Java / SpringBoot、Golang、PHP、JavaScript 等主流语言与框架。",
-      },
-      {
-        icon: Terminal,
-        title: "SyntaxFlow",
-        text: "自研的语法模式匹配 DSL，用贴近漏洞描述的语法直接编写检测规则。",
-      },
-      {
-        icon: PackageCheck,
-        title: "AI 双引擎",
-        text: "传统 SAST 与大模型协同，降低误报、提升真实漏洞检出率。",
-      },
+      { icon: ShieldCheck, title: "多语言支持", text: "覆盖 Java、Golang、PHP、JavaScript 等主流语言与框架。" },
+      { icon: Terminal, title: "SyntaxFlow", text: "用贴近漏洞描述的 DSL 编写可复用、可解释的检测规则。" },
+      { icon: PackageCheck, title: "AI 双引擎", text: "传统静态分析与大模型协同，提升真实漏洞检出效率。" },
     ],
   },
   Memfit: {
-    tag: "Agent",
-    title: "Memfit AI",
-    desc: "新一代安全领域工作 Agent。ReAct 与 Plan-Execute 递归耦合，由 Yaklang 驱动。",
+    title: "让 Memfit 执行安全任务。",
+    description: "由 Yaklang 驱动的安全工作 Agent，将规划、执行与验证组织为完整工作流。",
     installUrl: "https://memfit.ai",
     platforms: [
       {
-        id: "linux",
-        label: "访问 memfit.ai",
+        id: "web",
+        label: "Web",
+        prompt: "open https://memfit.ai",
         href: "https://memfit.ai",
-        external: true,
-        output: [
-          "递归式 Plan-Execute + ReAct 双引擎",
-          "调用 Yaklang 全栈安全能力",
-          "面向复杂攻防任务的智能体系统",
-        ],
+        output: ["进入 Memfit AI 工作空间", "组合 Plan-Execute 与 ReAct 双引擎", "调用 Yaklang 全栈安全能力"],
+        result: "创建任务并交给 Agent 执行",
       },
     ],
     guarantees: [
-      {
-        icon: Terminal,
-        title: "双引擎架构",
-        text: "宏观战略规划与微观战术执行递归耦合，可适应任意复杂度的安全任务。",
-      },
-      {
-        icon: ShieldCheck,
-        title: "Yaklang 驱动",
-        text: "底层直接调用 Yaklang 的安全工具链，行动可解释、可复现、可评测。",
-      },
-      {
-        icon: PackageCheck,
-        title: "能力可评测",
-        text: "配合 HackBenchmark 基准，对真实 Web 漏洞做可复现的攻防能力评测。",
-      },
+      { icon: Terminal, title: "双引擎架构", text: "宏观规划与微观执行递归协同，适应复杂安全任务。" },
+      { icon: ShieldCheck, title: "Yaklang 驱动", text: "直接调用 Yaklang 安全工具链，行动可解释且可复现。" },
+      { icon: PackageCheck, title: "能力可评测", text: "结合真实安全基准，对任务结果进行持续验证与评估。" },
     ],
   },
 };
 
-const LEGACY_FILES = [
-  { id: "windows-legacy", label: "Windows (Win7)", file: "windows-legacy-amd64.exe" },
-  { id: "linux-legacy-amd64", label: "Linux amd64 兼容版", file: "linux-legacy-amd64.AppImage" },
-  { id: "linux-legacy-arm64", label: "Linux arm64 兼容版", file: "linux-legacy-arm64.AppImage" },
-  { id: "macos-legacy-x64", label: "macOS Intel 兼容版", file: "darwin-legacy-x64.dmg" },
-  { id: "macos-legacy-arm64", label: "macOS Apple Silicon 兼容版", file: "darwin-legacy-arm64.dmg" },
+const LEGACY_FILES: DownloadAsset[] = [
+  { label: "Windows 7", file: "windows-legacy-amd64.exe" },
+  { label: "Linux x86_64", file: "linux-legacy-amd64.AppImage" },
+  { label: "Linux ARM64", file: "linux-legacy-arm64.AppImage" },
+  { label: "macOS Intel", file: "darwin-legacy-x64.dmg" },
+  { label: "macOS Apple Silicon", file: "darwin-legacy-arm64.dmg" },
 ];
+
+const productKeys = Object.keys(PRODUCTS) as ProductKey[];
 
 function getYakitUrl(version: string, file: string) {
   return `https://oss-qn.yaklang.com/yak/${version}/Yakit-${version}-${file}`;
 }
 
-function getOS(): "macos" | "windows" | "linux" {
-  if (typeof navigator === "undefined") return "macos";
-  const ua = navigator.userAgent.toLowerCase();
-  if (ua.includes("win")) return "windows";
-  if (ua.includes("mac") || ua.includes("darwin")) return "macos";
+function detectPlatform(): PlatformId {
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.includes("win")) return "windows";
+  if (userAgent.includes("mac") || userAgent.includes("darwin")) return "macos";
   return "linux";
 }
 
-export default function DownloadBlock() {
-  const defaultOS = getOS();
-  const firstProduct = PRODUCTS.Yakit;
-  const defaultActive = firstProduct.platforms.find((p) => p.id === defaultOS) ?? firstProduct.platforms[0];
+function GuaranteeItem({ guarantee }: { guarantee: Guarantee }) {
+  const Icon = guarantee.icon;
 
+  return (
+    <motion.div variants={item}>
+      <Icon className="h-5 w-5" style={{ color: "var(--hp-orange)" }} aria-hidden="true" />
+      <h3 className="mt-4 text-sm font-semibold" style={{ color: "var(--hp-ink)" }}>
+        {guarantee.title}
+      </h3>
+      <p className="mt-2 text-sm leading-relaxed" style={{ color: "var(--hp-ink-55)" }}>
+        {guarantee.text}
+      </p>
+    </motion.div>
+  );
+}
+
+export default function DownloadBlock() {
   const [activeProduct, setActiveProduct] = useState<ProductKey>("Yakit");
-  const [activeId, setActiveId] = useState<string>(defaultActive.id);
+  const [activeId, setActiveId] = useState<PlatformId>("macos");
   const [version, setVersion] = useState("");
-  const [sizes, setSizes] = useState<Record<string, number | null>>({});
   const [legacyOpen, setLegacyOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<number | null>(null);
   const reduceMotion = useReducedMotion();
 
+  const product = PRODUCTS[activeProduct];
+  const active = product.platforms.find((platform) => platform.id === activeId) ?? product.platforms[0];
+
   useEffect(() => {
-    let cancelled = false;
-    axios
-      .get("https://oss-qn.yaklang.com/yak/latest/yakit-version.txt")
-      .then((res) => {
-        if (cancelled) return;
-        const v = typeof res.data === "string" ? res.data.split("\n")[0].trim() : "";
-        setVersion(v);
-        Promise.all(
-          PRODUCTS.Yakit.platforms.map(async (p) => {
-            if (!p.file) return [p.id, null] as [string, null];
-            try {
-              const resp = await axios.head(getYakitUrl(v, p.file));
-              const len = resp.headers["content-length"];
-              if (len) {
-                const size = Math.ceil((Number(len) / 1024 / 1024) * 100) / 100;
-                return [p.id, size] as [string, number];
-              }
-            } catch {
-              // ignore
-            }
-            return [p.id, null] as [string, null];
-          })
-        ).then((entries) => {
-          if (!cancelled) setSizes(Object.fromEntries(entries));
-        });
-      })
-      .catch(() => {
-        // ignore
-      });
-    return () => {
-      cancelled = true;
-    };
+    setActiveId(detectPlatform());
   }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch("https://oss-qn.yaklang.com/yak/latest/yakit-version.txt", { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) throw new Error("Unable to load Yakit version");
+        return response.text();
+      })
+      .then((text) => setVersion(text.split("\n")[0].trim()))
+      .catch(() => undefined);
+
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!product.platforms.some((platform) => platform.id === activeId)) {
+      const detected = detectPlatform();
+      setActiveId(product.platforms.find((platform) => platform.id === detected)?.id ?? product.platforms[0].id);
+    }
+  }, [activeId, product]);
 
   useEffect(() => {
     return () => {
@@ -331,17 +285,9 @@ export default function DownloadBlock() {
     };
   }, []);
 
-  const product = PRODUCTS[activeProduct];
-  const active = product.platforms.find((p) => p.id === activeId) ?? product.platforms[0];
-
-  // 切换产品时，尝试保留当前 OS；若不存在则选第一个
-  useEffect(() => {
-    const matching = product.platforms.find((p) => p.id === activeId);
-    if (!matching) setActiveId(product.platforms[0].id);
-  }, [activeProduct]);
-
   const copyCommand = async () => {
     if (!active.command) return;
+
     try {
       await navigator.clipboard.writeText(active.command);
       setCopied(true);
@@ -352,14 +298,88 @@ export default function DownloadBlock() {
     }
   };
 
-  const handleFileDownload = (file: string) => {
-    if (!version) return;
-    window.location.href = getYakitUrl(version, file);
+  const selectProduct = (key: ProductKey) => {
+    const nextProduct = PRODUCTS[key];
+    const detected = detectPlatform();
+    setActiveProduct(key);
+    setActiveId(nextProduct.platforms.find((platform) => platform.id === detected)?.id ?? nextProduct.platforms[0].id);
+    setLegacyOpen(false);
+    setCopied(false);
   };
 
-  const isYakit = activeProduct === "Yakit";
-  const isCommand = !!active.command;
-  const isLink = !!active.href;
+  const renderAction = () => {
+    if (active.command) {
+      return (
+        <button
+          type="button"
+          onClick={copyCommand}
+          className="inline-flex h-9 min-w-[104px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 px-4 text-xs font-medium text-neutral-300 transition-colors hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            {copied ? (
+              <motion.span key="copied" initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -4 }} className="inline-flex items-center gap-2">
+                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                已复制
+              </motion.span>
+            ) : (
+              <motion.span key="copy" initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -4 }} className="inline-flex items-center gap-2">
+                <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                复制命令
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </button>
+      );
+    }
+
+    if (active.assets) {
+      return (
+        <div className="flex flex-wrap justify-end gap-2">
+          {active.assets.map((asset) =>
+            version ? (
+              <a
+                key={asset.file}
+                href={getYakitUrl(version, asset.file)}
+                className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-950 transition-opacity hover:opacity-90"
+                style={{ background: "var(--hp-orange)" }}
+              >
+                <Download className="h-3.5 w-3.5" aria-hidden="true" />
+                {asset.label}
+              </a>
+            ) : (
+              <span key={asset.file} className="inline-flex h-9 items-center rounded-full border border-white/15 px-4 text-xs text-neutral-500">
+                正在获取版本
+              </span>
+            ),
+          )}
+        </div>
+      );
+    }
+
+    if (active.href) {
+      return (
+        <a
+          href={active.href}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-950 transition-opacity hover:opacity-90"
+          style={{ background: "var(--hp-orange)" }}
+        >
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          打开
+        </a>
+      );
+    }
+
+    return null;
+  };
+
+  const prompt = active.command ?? active.prompt;
+  const terminalStyle: CSSProperties = {
+    background: "var(--hp-card-dark)",
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    boxShadow: "0 24px 64px rgba(33, 26, 18, 0.18)",
+  };
 
   return (
     <section className="w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-24">
@@ -368,234 +388,113 @@ export default function DownloadBlock() {
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-80px" }}
-        className="mx-auto flex w-full max-w-[1200px] flex-col items-center"
+        className="mx-auto flex w-full max-w-[1400px] flex-col items-center"
       >
-        {/* Section header */}
-        <motion.span variants={item} className="hp-mono text-xs" style={{ color: "var(--hp-orange)" }}>
-          DOWNLOAD
-        </motion.span>
         <motion.h2
+          key={`${activeProduct}-title`}
           variants={item}
-          className="hp-display mt-4 max-w-2xl text-center text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl"
+          className="hp-display max-w-3xl text-center text-3xl font-semibold tracking-normal sm:text-4xl md:text-5xl lg:text-6xl"
           style={{ color: "var(--hp-ink)" }}
         >
-          获取 Yak Project 核心产品
+          {product.title}
         </motion.h2>
-        <motion.p
-          variants={item}
-          className="mt-4 max-w-xl text-center text-sm leading-relaxed sm:text-base"
-          style={{ color: "var(--hp-ink-55)" }}
-        >
-          选择对应产品与平台，即可下载安装包或复制一键安装命令。
+
+        <motion.p variants={item} className="mt-6 max-w-xl text-center text-base leading-relaxed sm:text-lg" style={{ color: "var(--hp-ink-55)" }}>
+          {product.description}
         </motion.p>
 
-        {/* Product tabs */}
-        <motion.div variants={item} className="mt-10 flex flex-wrap justify-center gap-2">
-          {(Object.keys(PRODUCTS) as ProductKey[]).map((k) => (
+        <motion.div variants={item} className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 border-b" style={{ borderColor: "var(--hp-line)" }}>
+          {productKeys.map((key) => (
             <button
-              key={k}
-              onClick={() => {
-                setActiveProduct(k);
-                setLegacyOpen(false);
-              }}
-              className="relative cursor-pointer rounded-full px-5 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2"
-              style={{
-                color: activeProduct === k ? "#fff" : "var(--hp-ink, #211a12)",
-                border: activeProduct === k ? "none" : "1px solid var(--hp-line, rgba(33,26,18,0.12))",
-                background: activeProduct === k ? "var(--hp-orange, #ff7d23)" : "transparent",
-              }}
+              key={key}
+              type="button"
+              onClick={() => selectProduct(key)}
+              aria-pressed={activeProduct === key}
+              className="hp-mono relative cursor-pointer border-0 bg-transparent px-0 pb-3 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2"
+              style={{ color: activeProduct === key ? "var(--hp-orange)" : "var(--hp-ink-55)" }}
             >
-              {k}
+              {key}
+              {activeProduct === key && <motion.span layoutId="product-active-tab" className="absolute inset-x-0 -bottom-px h-0.5" style={{ background: "var(--hp-orange)" }} />}
             </button>
           ))}
         </motion.div>
 
-        {/* Terminal card */}
-        <motion.div variants={item} className="mt-8 w-full max-w-3xl">
-          <div
-            className="overflow-hidden rounded-2xl shadow-xl"
-            style={{
-              background: isYakit ? "#1a1512" : "var(--hp-card-dark, #1a1512)",
-              border: "1px solid rgba(255,255,255,0.08)",
-              boxShadow: "0 25px 60px rgba(0,0,0,0.18)",
-            }}
-          >
-            {/* Card header */}
-            <div className="flex items-center justify-between border-b border-white/10 px-4 py-3 sm:px-5">
-              <div className="flex items-center gap-3">
-                <span className="flex gap-1.5" aria-hidden="true">
+        <motion.div variants={item} className="mt-10 w-full max-w-3xl">
+          <div className="overflow-hidden rounded-2xl border shadow-xl" style={terminalStyle}>
+            <div className="flex flex-col gap-3 border-b border-white/10 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="flex shrink-0 gap-1.5" aria-hidden="true">
                   <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
-                  <span className="hidden h-2.5 w-2.5 rounded-full bg-white/20 sm:inline" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
                   <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
                 </span>
-                <span className="font-mono text-xs text-white/40">
-                  {product.title.toLowerCase()} · install
-                </span>
+                <span className="truncate font-mono text-xs text-neutral-500">{activeProduct.toLowerCase()} · install</span>
               </div>
-              <div className="flex rounded-full border border-white/10 bg-white/5 p-1">
-                {product.platforms.map((p) => (
+              <div className="flex max-w-full overflow-x-auto rounded-full border border-white/10 bg-white/5 p-1">
+                {product.platforms.map((platform) => (
                   <button
-                    key={p.id}
+                    key={platform.id}
                     type="button"
-                    onClick={() => setActiveId(p.id)}
-                    aria-pressed={activeId === p.id}
-                    className="relative cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    onClick={() => setActiveId(platform.id)}
+                    aria-pressed={active.id === platform.id}
+                    className="relative shrink-0 cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
                   >
-                    {activeId === p.id && (
+                    {active.id === platform.id && (
                       <motion.span
-                        layoutId="download-active-tab"
+                        layoutId="download-active-platform"
                         style={{ borderRadius: 9999 }}
                         transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
                         className="absolute inset-0 bg-white"
                       />
                     )}
-                    <span
-                      className={`relative z-10 transition-colors ${
-                        activeId === p.id ? "text-neutral-900" : "text-neutral-400 hover:text-white"
-                      }`}
-                    >
-                      {p.label}
+                    <span className={`relative z-10 transition-colors ${active.id === platform.id ? "text-neutral-900" : "text-neutral-400 hover:text-white"}`}>
+                      {platform.label}
                     </span>
                   </button>
                 ))}
               </div>
             </div>
 
-            {/* Card body */}
             <div className="px-5 py-6 sm:px-7 sm:py-7">
               <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                <div className="min-w-0 flex-1">
-                  {isCommand ? (
-                    <p className="break-words font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
-                      <span className="select-none text-neutral-500">$ </span>
-                      {active.command}
-                      {reduceMotion ? (
-                        <span
-                          aria-hidden="true"
-                          className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
-                        />
-                      ) : (
-                        <motion.span
-                          aria-hidden="true"
-                          className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
-                          animate={{ opacity: [1, 1, 0, 0] }}
-                          transition={{ duration: 1.1, repeat: Infinity, times: [0, 0.5, 0.5, 1], ease: "linear" }}
-                        />
-                      )}
-                    </p>
-                  ) : (
-                    <div className="font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
-                      {isYakit ? (
-                        <>
-                          <span className="select-none text-neutral-500">$ </span>
-                          <span>下载 {active.label} 安装包</span>
-                          <div className="mt-1 text-neutral-400">
-                            {active.subFile ? (
-                              <>
-                                Intel: {active.file} / Apple Silicon: {active.subFile}
-                              </>
-                            ) : (
-                              <>文件: {active.file}</>
-                            )}
-                            {version && (
-                              <span className="ml-2 text-neutral-500">
-                                · 版本 {version}
-                                {sizes[active.id] ? ` · ${sizes[active.id]} MB` : ""}
-                              </span>
-                            )}
-                          </div>
-                        </>
-                      ) : (
-                        <>
-                          <span className="select-none text-neutral-500">$ </span>
-                          <span>前往 {active.label}</span>
-                        </>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex shrink-0 gap-2">
-                  {isCommand && (
-                    <button
-                      type="button"
-                      onClick={copyCommand}
-                      className="inline-flex h-9 min-w-[100px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 px-4 text-xs font-medium text-neutral-300 transition-colors hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
-                    >
-                      <AnimatePresence mode="wait" initial={false}>
-                        {copied ? (
-                          <motion.span
-                            key="copied"
-                            initial={{ opacity: 0, y: 4 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -4 }}
-                            transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-                            className="inline-flex items-center gap-2"
-                          >
-                            <Check className="h-3.5 w-3.5" />
-                            已复制
-                          </motion.span>
-                        ) : (
-                          <motion.span
-                            key="copy"
-                            initial={{ opacity: 0, y: 4 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -4 }}
-                            transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-                            className="inline-flex items-center gap-2"
-                          >
-                            <Copy className="h-3.5 w-3.5" />
-                            复制
-                          </motion.span>
-                        )}
-                      </AnimatePresence>
-                    </button>
-                  )}
-
-                  {isYakit ? (
-                    <button
-                      type="button"
-                      onClick={() => handleFileDownload(active.file!)}
-                      disabled={!version}
-                      className="inline-flex h-9 shrink-0 cursor-pointer items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-900 transition-colors hover:opacity-90 disabled:opacity-50"
-                      style={{ background: "var(--hp-orange, #ff7d23)" }}
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                      下载
-                    </button>
-                  ) : isLink ? (
-                    <a
-                      href={active.href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-900 transition-colors hover:opacity-90"
-                      style={{ background: "var(--hp-orange, #ff7d23)" }}
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                      前往
-                    </a>
-                  ) : null}
-                </div>
+                <p className="min-w-0 break-words font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
+                  <span className="select-none text-neutral-500">$ </span>
+                  {prompt}
+                  {active.command &&
+                    (reduceMotion ? (
+                      <span aria-hidden="true" className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100" />
+                    ) : (
+                      <motion.span
+                        aria-hidden="true"
+                        className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
+                        animate={{ opacity: [1, 1, 0, 0] }}
+                        transition={{ duration: 1.1, repeat: Infinity, times: [0, 0.5, 0.5, 1], ease: "linear" }}
+                      />
+                    ))}
+                </p>
+                {renderAction()}
               </div>
 
-              {/* Output list */}
               <div className="mt-6 border-t border-white/10 pt-5">
-                <div className="min-h-[100px]">
+                <div className="min-h-[132px] sm:min-h-[120px]">
                   <AnimatePresence mode="wait" initial={false}>
                     <motion.ul
-                      key={active.id}
+                      key={`${activeProduct}-${active.id}`}
                       variants={outputList}
                       initial="hidden"
                       animate="visible"
                       exit={{ opacity: 0, transition: { duration: 0.15 } }}
                       className="space-y-2.5 font-mono text-[13px]"
                     >
-                      {(active.output || []).map((line) => (
+                      {active.output.map((line) => (
                         <motion.li key={line} variants={outputLine} className="flex items-center gap-2.5 text-neutral-400">
-                          <Check className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+                          <Check className="h-3.5 w-3.5 shrink-0 text-emerald-400" aria-hidden="true" />
                           <span className="min-w-0 break-words">{line}</span>
                         </motion.li>
                       ))}
+                      <motion.li variants={outputLine} className="pt-1.5 text-neutral-100">
+                        → {active.result}
+                      </motion.li>
                     </motion.ul>
                   </AnimatePresence>
                 </div>
@@ -604,97 +503,71 @@ export default function DownloadBlock() {
           </div>
         </motion.div>
 
-        {/* Meta line */}
-        <motion.div
-          variants={item}
-          className="mt-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs"
-          style={{ color: "var(--hp-ink-55)" }}
-        >
-          {isYakit ? (
-            <>
-              <span>最新版本: {version || "-"}</span>
-              <span aria-hidden="true">·</span>
-              <span>macOS / Windows / Linux</span>
-            </>
-          ) : (
-            <>
-              <span>{product.title}</span>
-              <span aria-hidden="true">·</span>
-              <a href={product.installUrl} target={product.installUrl.startsWith("http") ? "_blank" : undefined} rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
-                安装说明 <ArrowUpRight className="h-3 w-3" />
-              </a>
-            </>
-          )}
+        <motion.div variants={item} className="mt-5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs" style={{ color: "var(--hp-ink-55)" }}>
+          <span>{activeProduct === "Yakit" ? `v${version || "latest"}` : activeProduct}</span>
+          <span aria-hidden="true">·</span>
+          <span>{product.platforms.map((platform) => platform.label).join(" / ")}</span>
+          <span aria-hidden="true">·</span>
+          <span>Yak Project</span>
         </motion.div>
 
-        {/* Legacy versions (Yakit only) */}
-        {isYakit && (
-          <motion.div variants={item} className="mt-6 w-full max-w-3xl">
-            <button
+        {activeProduct === "Yakit" ? (
+          <>
+            <motion.button
+              variants={item}
               type="button"
-              onClick={() => setLegacyOpen(!legacyOpen)}
-              className="flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-xs font-medium transition-colors hover:bg-black/5"
-              style={{ borderColor: "var(--hp-line, rgba(33,26,18,0.12))", color: "var(--hp-ink-55)" }}
+              onClick={() => setLegacyOpen((open) => !open)}
+              aria-expanded={legacyOpen}
+              className="mt-8 inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent text-sm font-medium transition-colors hover:opacity-60 focus-visible:outline-none focus-visible:ring-2"
+              style={{ color: "var(--hp-ink)" }}
             >
-              {legacyOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-              下载兼容版本（旧系统）
-            </button>
+              旧系统兼容版本
+              <ChevronDown className={`h-4 w-4 transition-transform ${legacyOpen ? "rotate-180" : ""}`} aria-hidden="true" />
+            </motion.button>
             <AnimatePresence initial={false}>
               {legacyOpen && (
                 <motion.div
                   initial={{ height: 0, opacity: 0 }}
                   animate={{ height: "auto", opacity: 1 }}
                   exit={{ height: 0, opacity: 0 }}
-                  transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
-                  className="overflow-hidden"
+                  className="w-full max-w-3xl overflow-hidden"
                 >
-                  <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                    {LEGACY_FILES.map((l) => (
-                      <div
-                        key={l.id}
-                        className="flex items-center justify-between rounded-xl border p-3"
-                        style={{ borderColor: "var(--hp-line, rgba(33,26,18,0.08))" }}
-                      >
-                        <span className="text-sm" style={{ color: "var(--hp-ink)" }}>
-                          {l.label}
+                  <div className="mt-5 flex flex-wrap justify-center gap-x-5 gap-y-3 border-t pt-5" style={{ borderColor: "var(--hp-line)" }}>
+                    {LEGACY_FILES.map((asset) =>
+                      version ? (
+                        <a key={asset.file} href={getYakitUrl(version, asset.file)} className="inline-flex items-center gap-1.5 text-xs font-medium hover:opacity-60" style={{ color: "var(--hp-ink)" }}>
+                          <Download className="h-3.5 w-3.5" aria-hidden="true" />
+                          {asset.label}
+                        </a>
+                      ) : (
+                        <span key={asset.file} className="text-xs" style={{ color: "var(--hp-ink-55)" }}>
+                          {asset.label}
                         </span>
-                        <button
-                          type="button"
-                          onClick={() => handleFileDownload(l.file)}
-                          disabled={!version}
-                          className="rounded-full p-2 text-white transition-opacity hover:opacity-90 disabled:opacity-50"
-                          style={{ background: "var(--hp-orange)" }}
-                        >
-                          <Download className="h-4 w-4" />
-                        </button>
-                      </div>
-                    ))}
+                      ),
+                    )}
                   </div>
                 </motion.div>
               )}
             </AnimatePresence>
-          </motion.div>
+          </>
+        ) : (
+          <motion.a
+            variants={item}
+            href={product.installUrl}
+            target={product.installUrl.startsWith("http") ? "_blank" : undefined}
+            rel={product.installUrl.startsWith("http") ? "noreferrer" : undefined}
+            className="mt-8 inline-flex items-center gap-1.5 text-sm font-medium transition-colors hover:opacity-60 focus-visible:outline-none focus-visible:ring-2"
+            style={{ color: "var(--hp-ink)" }}
+          >
+            查看完整说明
+            <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+          </motion.a>
         )}
 
-        {/* Guarantees */}
         <div className="mt-16 grid w-full max-w-4xl grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8">
-          {(() => {
-            const guarantees: { icon: React.ElementType; title: string; text: string }[] = product.guarantees || [];
-            return guarantees.map((point) => {
-              const Icon: React.ElementType = point.icon;
-              return (
-                <motion.div key={point.title} variants={item}>
-                  <Icon className="h-5 w-5" style={{ color: "var(--hp-orange)" }} aria-hidden="true" />
-                  <h3 className="mt-4 text-sm font-semibold" style={{ color: "var(--hp-ink)" }}>
-                    {point.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed" style={{ color: "var(--hp-ink-55)" }}>
-                    {point.text}
-                  </p>
-                </motion.div>
-              );
-            });
-          })()}
+          {product.guarantees.map((guarantee) => (
+            <GuaranteeItem key={`${activeProduct}-${guarantee.title}`} guarantee={guarantee} />
+          ))}
         </div>
       </motion.div>
     </section>

--- a/src/components/homepage/DownloadBlock.tsx
+++ b/src/components/homepage/DownloadBlock.tsx
@@ -1,0 +1,702 @@
+// @ts-nocheck
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import axios from "axios";
+import {
+  ArrowUpRight,
+  Check,
+  ChevronDown,
+  Copy,
+  Download,
+  ExternalLink,
+  Monitor,
+  MonitorSmartphone,
+  PackageCheck,
+  ShieldCheck,
+  Terminal,
+} from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion, type Variants } from "motion/react";
+
+const container: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.08, delayChildren: 0.05 } },
+};
+
+const item: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+const outputList: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.07 } },
+};
+
+const outputLine: Variants = {
+  hidden: { opacity: 0, y: 6 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+type ProductKey = "Yakit" | "Yaklang" | "IRify" | "Memfit";
+
+interface PlatformSpec {
+  id: string;
+  label: string;
+  command?: string;
+  output?: string[];
+  file?: string;
+  subFile?: string;
+  href?: string;
+  external?: boolean;
+}
+
+interface ProductSpec {
+  tag: string;
+  title: string;
+  desc: string;
+  installUrl: string;
+  platforms: PlatformSpec[];
+  guarantees?: { icon: React.ComponentType<{ className?: string; style?: React.CSSProperties; "aria-hidden"?: boolean }>; title: string; text: string }[];
+}
+
+const PRODUCTS: Record<ProductKey, ProductSpec> = {
+  Yakit: {
+    tag: "下载",
+    title: "YAK IDE (Yakit)",
+    desc: "由 Yaklang 驱动的交互式网络安全测试平台。安装 Yakit 即获得 Yak 语言运行环境与全部图形化能力。",
+    installUrl: "/products/legacy/download_and_install",
+    platforms: [
+      {
+        id: "macos",
+        label: "macOS",
+        file: "darwin-x64.dmg",
+        subFile: "darwin-arm64.dmg",
+        output: [
+          "下载 Yakit 最新版 · macOS",
+          "同时支持 Intel 与 Apple Silicon 芯片",
+          "安装后自动集成 Yak 语言运行环境",
+        ],
+      },
+      {
+        id: "windows",
+        label: "Windows",
+        file: "windows-amd64.exe",
+        output: [
+          "下载 Yakit 最新版 · Windows x86_64",
+          "支持 Windows 10 / 11",
+          "安装后自动集成 Yak 语言运行环境",
+        ],
+      },
+      {
+        id: "linux",
+        label: "Linux",
+        file: "linux-amd64.AppImage",
+        subFile: "linux-arm64.AppImage",
+        output: [
+          "下载 Yakit 最新版 · Linux",
+          "支持 x86_64 与 ARM64 架构",
+          "兼容统信 UOS、麒麟等国产系统",
+        ],
+      },
+    ],
+    guarantees: [
+      {
+        icon: ShieldCheck,
+        title: "持续更新",
+        text: "Yakit 每月发布新版本，自动检测并提醒升级，保证安全能力与时俱进。",
+      },
+      {
+        icon: Terminal,
+        title: "内置 Yak 引擎",
+        text: "安装 Yakit 即自动配置 Yak 语言运行环境，无需单独安装语言二进制。",
+      },
+      {
+        icon: PackageCheck,
+        title: "跨平台一致",
+        text: "macOS / Windows / Linux 三端统一界面与能力，团队协同无壁垒。",
+      },
+    ],
+  },
+  Yaklang: {
+    tag: "命令行",
+    title: "Yaklang 语言环境",
+    desc: "面向网络安全的 CDSL 领域编程语言。一行命令完成安装，支持 macOS / Linux / Windows。",
+    installUrl: "/docs/startup",
+    platforms: [
+      {
+        id: "macos",
+        label: "macOS / Linux",
+        command: "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)",
+        output: [
+          "自动检测操作系统与架构",
+          "下载并安装最新 Yak 二进制",
+          "完成环境变量配置",
+        ],
+      },
+      {
+        id: "windows",
+        label: "Windows",
+        command: "powershell (new-object System.Net.WebClient).DownloadFile('https://oss-qn.yaklang.com/yak/latest/yak_windows_amd64.exe','yak.exe'); yak.exe install",
+        output: [
+          "下载 Windows 版 Yak 安装器",
+          "自动完成安装与环境配置",
+          "命令行输入 yak 即可使用",
+        ],
+      },
+      {
+        id: "linux",
+        label: "GitHub Releases",
+        href: "https://github.com/yaklang/yaklang/releases",
+        external: true,
+        output: [
+          "所有预编译二进制资产",
+          "包含各平台历史版本",
+          "适合 CI / 容器 / 离线部署",
+        ],
+      },
+    ],
+    guarantees: [
+      {
+        icon: Terminal,
+        title: "一行安装",
+        text: "macOS 与 Linux 只需一条 curl 命令即可将 Yak 安装到 PATH。",
+      },
+      {
+        icon: ShieldCheck,
+        title: "完全开源",
+        text: "Yaklang 核心遵循 AGPL-3.0 开源，源码托管于 GitHub，接受社区共建。",
+      },
+      {
+        icon: PackageCheck,
+        title: "跨平台",
+        text: "支持 macOS、Linux、Windows 及统信 UOS、麒麟等国产化系统。",
+      },
+    ],
+  },
+  IRify: {
+    tag: "在线服务",
+    title: "IRify 代码审计平台",
+    desc: "兼具 SAST 与 AI 双引擎的代码安全分析系统。支持多语言源码建模、数据流分析与漏洞挖掘。",
+    installUrl: "https://ssa.to",
+    platforms: [
+      {
+        id: "linux",
+        label: "在线使用",
+        href: "https://ssa.to",
+        external: true,
+        output: [
+          "基于 SSA IR 的多语言代码分析",
+          "SyntaxFlow 一行表达漏洞规则",
+          "SAST + AI 双引擎协同审计",
+        ],
+      },
+    ],
+    guarantees: [
+      {
+        icon: ShieldCheck,
+        title: "多语言支持",
+        text: "深度支持 Java / SpringBoot、Golang、PHP、JavaScript 等主流语言与框架。",
+      },
+      {
+        icon: Terminal,
+        title: "SyntaxFlow",
+        text: "自研的语法模式匹配 DSL，用贴近漏洞描述的语法直接编写检测规则。",
+      },
+      {
+        icon: PackageCheck,
+        title: "AI 双引擎",
+        text: "传统 SAST 与大模型协同，降低误报、提升真实漏洞检出率。",
+      },
+    ],
+  },
+  Memfit: {
+    tag: "Agent",
+    title: "Memfit AI",
+    desc: "新一代安全领域工作 Agent。ReAct 与 Plan-Execute 递归耦合，由 Yaklang 驱动。",
+    installUrl: "https://memfit.ai",
+    platforms: [
+      {
+        id: "linux",
+        label: "访问 memfit.ai",
+        href: "https://memfit.ai",
+        external: true,
+        output: [
+          "递归式 Plan-Execute + ReAct 双引擎",
+          "调用 Yaklang 全栈安全能力",
+          "面向复杂攻防任务的智能体系统",
+        ],
+      },
+    ],
+    guarantees: [
+      {
+        icon: Terminal,
+        title: "双引擎架构",
+        text: "宏观战略规划与微观战术执行递归耦合，可适应任意复杂度的安全任务。",
+      },
+      {
+        icon: ShieldCheck,
+        title: "Yaklang 驱动",
+        text: "底层直接调用 Yaklang 的安全工具链，行动可解释、可复现、可评测。",
+      },
+      {
+        icon: PackageCheck,
+        title: "能力可评测",
+        text: "配合 HackBenchmark 基准，对真实 Web 漏洞做可复现的攻防能力评测。",
+      },
+    ],
+  },
+};
+
+const LEGACY_FILES = [
+  { id: "windows-legacy", label: "Windows (Win7)", file: "windows-legacy-amd64.exe" },
+  { id: "linux-legacy-amd64", label: "Linux amd64 兼容版", file: "linux-legacy-amd64.AppImage" },
+  { id: "linux-legacy-arm64", label: "Linux arm64 兼容版", file: "linux-legacy-arm64.AppImage" },
+  { id: "macos-legacy-x64", label: "macOS Intel 兼容版", file: "darwin-legacy-x64.dmg" },
+  { id: "macos-legacy-arm64", label: "macOS Apple Silicon 兼容版", file: "darwin-legacy-arm64.dmg" },
+];
+
+function getYakitUrl(version: string, file: string) {
+  return `https://oss-qn.yaklang.com/yak/${version}/Yakit-${version}-${file}`;
+}
+
+function getOS(): "macos" | "windows" | "linux" {
+  if (typeof navigator === "undefined") return "macos";
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes("win")) return "windows";
+  if (ua.includes("mac") || ua.includes("darwin")) return "macos";
+  return "linux";
+}
+
+export default function DownloadBlock() {
+  const defaultOS = getOS();
+  const firstProduct = PRODUCTS.Yakit;
+  const defaultActive = firstProduct.platforms.find((p) => p.id === defaultOS) ?? firstProduct.platforms[0];
+
+  const [activeProduct, setActiveProduct] = useState<ProductKey>("Yakit");
+  const [activeId, setActiveId] = useState<string>(defaultActive.id);
+  const [version, setVersion] = useState("");
+  const [sizes, setSizes] = useState<Record<string, number | null>>({});
+  const [legacyOpen, setLegacyOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+  const reduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    let cancelled = false;
+    axios
+      .get("https://oss-qn.yaklang.com/yak/latest/yakit-version.txt")
+      .then((res) => {
+        if (cancelled) return;
+        const v = typeof res.data === "string" ? res.data.split("\n")[0].trim() : "";
+        setVersion(v);
+        Promise.all(
+          PRODUCTS.Yakit.platforms.map(async (p) => {
+            if (!p.file) return [p.id, null] as [string, null];
+            try {
+              const resp = await axios.head(getYakitUrl(v, p.file));
+              const len = resp.headers["content-length"];
+              if (len) {
+                const size = Math.ceil((Number(len) / 1024 / 1024) * 100) / 100;
+                return [p.id, size] as [string, number];
+              }
+            } catch {
+              // ignore
+            }
+            return [p.id, null] as [string, null];
+          })
+        ).then((entries) => {
+          if (!cancelled) setSizes(Object.fromEntries(entries));
+        });
+      })
+      .catch(() => {
+        // ignore
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const product = PRODUCTS[activeProduct];
+  const active = product.platforms.find((p) => p.id === activeId) ?? product.platforms[0];
+
+  // 切换产品时，尝试保留当前 OS；若不存在则选第一个
+  useEffect(() => {
+    const matching = product.platforms.find((p) => p.id === activeId);
+    if (!matching) setActiveId(product.platforms[0].id);
+  }, [activeProduct]);
+
+  const copyCommand = async () => {
+    if (!active.command) return;
+    try {
+      await navigator.clipboard.writeText(active.command);
+      setCopied(true);
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const handleFileDownload = (file: string) => {
+    if (!version) return;
+    window.location.href = getYakitUrl(version, file);
+  };
+
+  const isYakit = activeProduct === "Yakit";
+  const isCommand = !!active.command;
+  const isLink = !!active.href;
+
+  return (
+    <section className="w-full px-4 py-16 sm:px-6 sm:py-20 lg:px-8 lg:py-24">
+      <motion.div
+        variants={container}
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, margin: "-80px" }}
+        className="mx-auto flex w-full max-w-[1200px] flex-col items-center"
+      >
+        {/* Section header */}
+        <motion.span variants={item} className="hp-mono text-xs" style={{ color: "var(--hp-orange)" }}>
+          DOWNLOAD
+        </motion.span>
+        <motion.h2
+          variants={item}
+          className="hp-display mt-4 max-w-2xl text-center text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl"
+          style={{ color: "var(--hp-ink)" }}
+        >
+          获取 Yak Project 核心产品
+        </motion.h2>
+        <motion.p
+          variants={item}
+          className="mt-4 max-w-xl text-center text-sm leading-relaxed sm:text-base"
+          style={{ color: "var(--hp-ink-55)" }}
+        >
+          选择对应产品与平台，即可下载安装包或复制一键安装命令。
+        </motion.p>
+
+        {/* Product tabs */}
+        <motion.div variants={item} className="mt-10 flex flex-wrap justify-center gap-2">
+          {(Object.keys(PRODUCTS) as ProductKey[]).map((k) => (
+            <button
+              key={k}
+              onClick={() => {
+                setActiveProduct(k);
+                setLegacyOpen(false);
+              }}
+              className="relative cursor-pointer rounded-full px-5 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2"
+              style={{
+                color: activeProduct === k ? "#fff" : "var(--hp-ink, #211a12)",
+                border: activeProduct === k ? "none" : "1px solid var(--hp-line, rgba(33,26,18,0.12))",
+                background: activeProduct === k ? "var(--hp-orange, #ff7d23)" : "transparent",
+              }}
+            >
+              {k}
+            </button>
+          ))}
+        </motion.div>
+
+        {/* Terminal card */}
+        <motion.div variants={item} className="mt-8 w-full max-w-3xl">
+          <div
+            className="overflow-hidden rounded-2xl shadow-xl"
+            style={{
+              background: isYakit ? "#1a1512" : "var(--hp-card-dark, #1a1512)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              boxShadow: "0 25px 60px rgba(0,0,0,0.18)",
+            }}
+          >
+            {/* Card header */}
+            <div className="flex items-center justify-between border-b border-white/10 px-4 py-3 sm:px-5">
+              <div className="flex items-center gap-3">
+                <span className="flex gap-1.5" aria-hidden="true">
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                  <span className="hidden h-2.5 w-2.5 rounded-full bg-white/20 sm:inline" />
+                  <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
+                </span>
+                <span className="font-mono text-xs text-white/40">
+                  {product.title.toLowerCase()} · install
+                </span>
+              </div>
+              <div className="flex rounded-full border border-white/10 bg-white/5 p-1">
+                {product.platforms.map((p) => (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => setActiveId(p.id)}
+                    aria-pressed={activeId === p.id}
+                    className="relative cursor-pointer rounded-full px-3 py-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                  >
+                    {activeId === p.id && (
+                      <motion.span
+                        layoutId="download-active-tab"
+                        style={{ borderRadius: 9999 }}
+                        transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+                        className="absolute inset-0 bg-white"
+                      />
+                    )}
+                    <span
+                      className={`relative z-10 transition-colors ${
+                        activeId === p.id ? "text-neutral-900" : "text-neutral-400 hover:text-white"
+                      }`}
+                    >
+                      {p.label}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Card body */}
+            <div className="px-5 py-6 sm:px-7 sm:py-7">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0 flex-1">
+                  {isCommand ? (
+                    <p className="break-words font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
+                      <span className="select-none text-neutral-500">$ </span>
+                      {active.command}
+                      {reduceMotion ? (
+                        <span
+                          aria-hidden="true"
+                          className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
+                        />
+                      ) : (
+                        <motion.span
+                          aria-hidden="true"
+                          className="ml-1.5 inline-block h-[1.05em] w-[7px] align-middle bg-neutral-100"
+                          animate={{ opacity: [1, 1, 0, 0] }}
+                          transition={{ duration: 1.1, repeat: Infinity, times: [0, 0.5, 0.5, 1], ease: "linear" }}
+                        />
+                      )}
+                    </p>
+                  ) : (
+                    <div className="font-mono text-sm leading-relaxed text-neutral-100 sm:text-[15px]">
+                      {isYakit ? (
+                        <>
+                          <span className="select-none text-neutral-500">$ </span>
+                          <span>下载 {active.label} 安装包</span>
+                          <div className="mt-1 text-neutral-400">
+                            {active.subFile ? (
+                              <>
+                                Intel: {active.file} / Apple Silicon: {active.subFile}
+                              </>
+                            ) : (
+                              <>文件: {active.file}</>
+                            )}
+                            {version && (
+                              <span className="ml-2 text-neutral-500">
+                                · 版本 {version}
+                                {sizes[active.id] ? ` · ${sizes[active.id]} MB` : ""}
+                              </span>
+                            )}
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <span className="select-none text-neutral-500">$ </span>
+                          <span>前往 {active.label}</span>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex shrink-0 gap-2">
+                  {isCommand && (
+                    <button
+                      type="button"
+                      onClick={copyCommand}
+                      className="inline-flex h-9 min-w-[100px] shrink-0 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 px-4 text-xs font-medium text-neutral-300 transition-colors hover:border-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+                    >
+                      <AnimatePresence mode="wait" initial={false}>
+                        {copied ? (
+                          <motion.span
+                            key="copied"
+                            initial={{ opacity: 0, y: 4 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -4 }}
+                            transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                            className="inline-flex items-center gap-2"
+                          >
+                            <Check className="h-3.5 w-3.5" />
+                            已复制
+                          </motion.span>
+                        ) : (
+                          <motion.span
+                            key="copy"
+                            initial={{ opacity: 0, y: 4 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -4 }}
+                            transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                            className="inline-flex items-center gap-2"
+                          >
+                            <Copy className="h-3.5 w-3.5" />
+                            复制
+                          </motion.span>
+                        )}
+                      </AnimatePresence>
+                    </button>
+                  )}
+
+                  {isYakit ? (
+                    <button
+                      type="button"
+                      onClick={() => handleFileDownload(active.file!)}
+                      disabled={!version}
+                      className="inline-flex h-9 shrink-0 cursor-pointer items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-900 transition-colors hover:opacity-90 disabled:opacity-50"
+                      style={{ background: "var(--hp-orange, #ff7d23)" }}
+                    >
+                      <Download className="h-3.5 w-3.5" />
+                      下载
+                    </button>
+                  ) : isLink ? (
+                    <a
+                      href={active.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex h-9 shrink-0 items-center gap-2 rounded-full px-4 text-xs font-medium text-neutral-900 transition-colors hover:opacity-90"
+                      style={{ background: "var(--hp-orange, #ff7d23)" }}
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                      前往
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+
+              {/* Output list */}
+              <div className="mt-6 border-t border-white/10 pt-5">
+                <div className="min-h-[100px]">
+                  <AnimatePresence mode="wait" initial={false}>
+                    <motion.ul
+                      key={active.id}
+                      variants={outputList}
+                      initial="hidden"
+                      animate="visible"
+                      exit={{ opacity: 0, transition: { duration: 0.15 } }}
+                      className="space-y-2.5 font-mono text-[13px]"
+                    >
+                      {(active.output || []).map((line) => (
+                        <motion.li key={line} variants={outputLine} className="flex items-center gap-2.5 text-neutral-400">
+                          <Check className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
+                          <span className="min-w-0 break-words">{line}</span>
+                        </motion.li>
+                      ))}
+                    </motion.ul>
+                  </AnimatePresence>
+                </div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Meta line */}
+        <motion.div
+          variants={item}
+          className="mt-4 flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 font-mono text-xs"
+          style={{ color: "var(--hp-ink-55)" }}
+        >
+          {isYakit ? (
+            <>
+              <span>最新版本: {version || "-"}</span>
+              <span aria-hidden="true">·</span>
+              <span>macOS / Windows / Linux</span>
+            </>
+          ) : (
+            <>
+              <span>{product.title}</span>
+              <span aria-hidden="true">·</span>
+              <a href={product.installUrl} target={product.installUrl.startsWith("http") ? "_blank" : undefined} rel="noreferrer" className="inline-flex items-center gap-1 hover:underline">
+                安装说明 <ArrowUpRight className="h-3 w-3" />
+              </a>
+            </>
+          )}
+        </motion.div>
+
+        {/* Legacy versions (Yakit only) */}
+        {isYakit && (
+          <motion.div variants={item} className="mt-6 w-full max-w-3xl">
+            <button
+              type="button"
+              onClick={() => setLegacyOpen(!legacyOpen)}
+              className="flex w-full items-center justify-center gap-2 rounded-full border px-4 py-2 text-xs font-medium transition-colors hover:bg-black/5"
+              style={{ borderColor: "var(--hp-line, rgba(33,26,18,0.12))", color: "var(--hp-ink-55)" }}
+            >
+              {legacyOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              下载兼容版本（旧系统）
+            </button>
+            <AnimatePresence initial={false}>
+              {legacyOpen && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+                  className="overflow-hidden"
+                >
+                  <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                    {LEGACY_FILES.map((l) => (
+                      <div
+                        key={l.id}
+                        className="flex items-center justify-between rounded-xl border p-3"
+                        style={{ borderColor: "var(--hp-line, rgba(33,26,18,0.08))" }}
+                      >
+                        <span className="text-sm" style={{ color: "var(--hp-ink)" }}>
+                          {l.label}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleFileDownload(l.file)}
+                          disabled={!version}
+                          className="rounded-full p-2 text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                          style={{ background: "var(--hp-orange)" }}
+                        >
+                          <Download className="h-4 w-4" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        )}
+
+        {/* Guarantees */}
+        <div className="mt-16 grid w-full max-w-4xl grid-cols-1 gap-10 sm:grid-cols-3 sm:gap-8">
+          {(() => {
+            const guarantees: { icon: React.ElementType; title: string; text: string }[] = product.guarantees || [];
+            return guarantees.map((point) => {
+              const Icon: React.ElementType = point.icon;
+              return (
+                <motion.div key={point.title} variants={item}>
+                  <Icon className="h-5 w-5" style={{ color: "var(--hp-orange)" }} aria-hidden="true" />
+                  <h3 className="mt-4 text-sm font-semibold" style={{ color: "var(--hp-ink)" }}>
+                    {point.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed" style={{ color: "var(--hp-ink-55)" }}>
+                    {point.text}
+                  </p>
+                </motion.div>
+              );
+            });
+          })()}
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/homepage/NewHomePage.tsx
+++ b/src/components/homepage/NewHomePage.tsx
@@ -1,0 +1,1068 @@
+import React, { useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { Hero24 } from "./hero-24";
+import DownloadBlock from "./DownloadBlock";
+import "./homepage.scss";
+
+const fadeUp = {
+  initial: { opacity: 0, y: 24 },
+  whileInView: { opacity: 1, y: 0 },
+  viewport: { once: true, margin: "-80px" },
+  transition: { duration: 0.8, ease: [0.22, 1, 0.36, 1] as const },
+};
+
+const LINKS = {
+  github: "https://github.com/yaklang",
+  yaklang: "https://yaklang.com",
+  yakDocs: "/docs/intro",
+  yakitDocs: "/products/intro",
+  irify: "https://ssa.to",
+  irifyDocs: "https://ssa.to/docs/intro",
+  memfit: "https://memfit.ai",
+  memfitDocs: "https://memfit.ai/docs/help/quick-start/installation/",
+  hackSkills: "https://skills.hackbenchmark.com",
+  hackBenchmark: "https://hackbenchmark.com",
+  yaklab: "/Yaklab/vulinbox/",
+  blog: "/blog",
+  download: "/download",
+  team: "/team",
+  opensource: "/opensource",
+};
+
+// ─── Shared ────────────────────────────────────────────
+
+function SectionHead({
+  tag,
+  title,
+  desc,
+}: {
+  tag: string;
+  title: string;
+  desc: string;
+}) {
+  return (
+    <motion.div {...fadeUp}>
+      <p className="hp-mono" style={{ color: "var(--hp-orange)" }}>
+        {tag}
+      </p>
+      <h2
+        className="hp-display mt-4 text-2xl font-semibold tracking-tight sm:text-3xl md:text-5xl"
+        style={{ lineHeight: 1.2 }}
+      >
+        {title}
+      </h2>
+      <p
+        className="mt-4 text-sm leading-relaxed"
+        style={{ maxWidth: 560, color: "var(--hp-ink-55)" }}
+      >
+        {desc}
+      </p>
+    </motion.div>
+  );
+}
+
+function WatercolorBg(props: Record<string, any>) {
+  return (
+    <BrowserOnly fallback={<div className="absolute inset-0 bg-[#150d06]" />}>
+      {() => {
+        const Watercolor =
+          require("../react-bits/watercolor").default;
+        return <Watercolor {...props} />;
+      }}
+    </BrowserOnly>
+  );
+}
+
+function StaggeredTextClient(props: Record<string, any>) {
+  return (
+    <BrowserOnly fallback={<span>{props.text}</span>}>
+      {() => {
+        const StaggeredText =
+          require("../react-bits/staggered-text").default;
+        return <StaggeredText {...props} />;
+      }}
+    </BrowserOnly>
+  );
+}
+
+// ─── Hero Block (Hero 24 风格: 左内容右 NeuroNoise 背景) ───
+
+function HeroBlock() {
+  return <Hero24 />;
+}
+
+
+// ─── Marquee Block ─────────────────────────────────────
+
+function MarqueeBlock() {
+  const words =
+    "CDSL-YAK — SSA IR — SYNTAXFLOW — YAK VM — MITM PROXY — WEB FUZZER — PLAN-EXECUTE — REACT ENGINE — MCP PROTOCOL — RAG SYSTEM — ";
+
+  return (
+    <div
+      className="overflow-hidden py-3"
+      style={{
+        borderTop: "1px solid var(--hp-line)",
+        borderBottom: "1px solid var(--hp-line)",
+        background: "var(--hp-card-dark)",
+      }}
+    >
+      <div className="hp-marquee-track flex w-max whitespace-nowrap">
+        {[0, 1].map((i) => (
+          <span
+            key={i}
+            className="hp-mono px-2"
+            style={{ color: "rgba(250,246,239,0.7)" }}
+          >
+            {words.repeat(3)}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Products Block ────────────────────────────────────
+
+function ProductsBlock() {
+  const products = [
+    {
+      no: "01",
+      name: "Yaklang",
+      tag: "网络安全领域专用语言",
+      desc: "面向网络安全场景设计的 CDSL 与虚拟机引擎，把扫描、流量分析、漏洞验证与自动化编排统一为可编程能力。",
+      features: [
+        "图灵完备的 CDSL 语言",
+        "YakVM 栈式字节码虚拟机",
+        "丰富的安全标准库",
+        "LSP / DSP 语言服务",
+      ],
+      href: LINKS.yakDocs,
+    },
+    {
+      no: "02",
+      name: "Yakit",
+      tag: "ALL-IN-ONE 安全测试平台",
+      desc: "由 Yaklang 驱动的交互式安全测试平台，可百分百替代 BurpSuite 的 MITM 劫持平台。",
+      features: [
+        "MITM 交互式劫持",
+        "可视化 Web Fuzzer",
+        "MITM 被动扫描 GUI",
+        "嵌入式执行 + 热加载",
+      ],
+      href: LINKS.yakitDocs,
+    },
+    {
+      no: "03",
+      name: "IRify",
+      tag: "SAST + AI 双引擎代码审计",
+      desc: "基于 SSA IR 中间表示的静态代码分析平台，用 SyntaxFlow 一行表达一个漏洞规则。",
+      features: [
+        "SSA 双向数据流分析",
+        "SyntaxFlow 规则引擎",
+        "AI 代码审计引擎",
+        "Java / Go / PHP / JS 多语言",
+      ],
+      href: LINKS.irify,
+    },
+    {
+      no: "04",
+      name: "Memfit AI",
+      tag: "安全领域工作 Agent",
+      desc: "ReAct 与 Plan-Execute 递归耦合的混合智能体架构，融合宏观战略规划与微观战术执行。",
+      features: [
+        "Plan + ReAct 双引擎",
+        "工具与 Forges 系统",
+        "RAG 知识检索",
+        "长期记忆系统",
+      ],
+      href: LINKS.memfit,
+    },
+  ];
+
+  return (
+    <section id="products" className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="PRODUCT ECOSYSTEM — 产品生态"
+          title="从安全语言到智能代理的完整产品栈"
+          desc="Yaklang 提供统一能力基座，Yakit、IRify 与 Memfit AI 分别服务于安全测试、代码分析和复杂任务执行。"
+        />
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 sm:grid-cols-2">
+          {products.map((p, i) => (
+            <motion.a
+              key={p.name}
+              href={p.href}
+              target={p.href.startsWith("/") ? undefined : "_blank"}
+              rel={p.href.startsWith("/") ? undefined : "noreferrer"}
+              className="hp-card group flex flex-col p-6 sm:p-8"
+              style={{ textDecoration: "none", color: "inherit" }}
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.1 }}
+            >
+              <p className="hp-mono" style={{ color: "var(--hp-ink-35)" }}>
+                {p.no} / PRODUCT
+              </p>
+              <h3
+                className="hp-display mt-4 text-2xl font-semibold tracking-tight sm:text-3xl"
+              >
+                {p.name}
+              </h3>
+              <p
+                className="mt-1 text-sm font-semibold"
+                style={{ color: "var(--hp-orange)" }}
+              >
+                {p.tag}
+              </p>
+              <p
+                className="mt-4 text-sm leading-relaxed"
+                style={{ color: "var(--hp-ink-55)" }}
+              >
+                {p.desc}
+              </p>
+              <ul
+                className="mt-6 flex flex-col gap-2 pt-5"
+                style={{ borderTop: "1px solid var(--hp-line)" }}
+              >
+                {p.features.map((f) => (
+                  <li
+                    key={f}
+                    className="flex items-center gap-2 text-[13px]"
+                    style={{ color: "var(--hp-ink-70)" }}
+                  >
+                    <span
+                      className="font-mono"
+                      style={{ color: "var(--hp-orange)" }}
+                    >
+                      →
+                    </span>
+                    {f}
+                  </li>
+                ))}
+              </ul>
+              <p
+                className="hp-mono mt-auto pt-6"
+                style={{ color: "var(--hp-ink-35)", transition: "color 0.25s" }}
+              >
+                了解更多 ↗
+              </p>
+            </motion.a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Showcase Block ────────────────────────────────────
+
+function ShowcaseBlock() {
+  const showcases = [
+    {
+      title: "Yaklang · CDSL 领域语言",
+      subtitle: "为网络安全而生的编程语言",
+      desc: "图灵完备 · 强类型 + 动态类型 · 编译字节码 · 单二进制跨平台 · 开箱即用",
+      code: `# 10 行代码完成 C 段扫描 + CVE 检测
+res = synscan.Scan("192.168.1.1/24", "80,443,8080")~
+for result in res {
+    addr = str.HostPort(result.Host, result.Port)
+    poc.HTTP(addr, poc.https(result.Port == 443))~
+}`,
+      visual: "yaklang",
+    },
+    {
+      title: "Yakit · 安全测试平台",
+      subtitle: "BurpSuite 国产化替代",
+      desc: "MITM 劫持 · Web Fuzzer · 被动扫描 · 端口扫描 · 反连 · 插件商店 · AI Agent",
+      img: "/img/home/third/mitm-1.png",
+      visual: "yakit",
+    },
+  ];
+
+  return (
+    <section className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="SHOWCASE — 产品演出"
+          title="安全能力的最佳实践"
+          desc="从一门语言到一个平台，Yak Project 把安全能力融合做成了可被复用的工程基座。"
+        />
+        <div className="mt-10 flex flex-col gap-4 sm:mt-12">
+          {showcases.map((s, i) => (
+            <motion.div
+              key={s.title}
+              className="hp-card overflow-hidden"
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.1 }}
+            >
+              <div className="flex flex-col lg:flex-row">
+                <div className="flex flex-col justify-center p-6 sm:p-8 lg:w-1/2 lg:p-10">
+                  <p className="hp-mono" style={{ color: "var(--hp-orange)" }}>
+                    {s.subtitle}
+                  </p>
+                  <h3
+                    className="hp-display mt-3 text-xl font-semibold tracking-tight sm:text-2xl"
+                  >
+                    {s.title}
+                  </h3>
+                  <p
+                    className="mt-3 text-sm leading-relaxed"
+                    style={{ color: "var(--hp-ink-55)" }}
+                  >
+                    {s.desc}
+                  </p>
+                  {s.code && (
+                    <pre
+                      className="mt-6 overflow-x-auto rounded-xl p-4 text-xs leading-relaxed"
+                      style={{
+                        background: "var(--hp-card-dark)",
+                        color: "rgba(250,246,239,0.85)",
+                        fontFamily: "var(--hp-font-mono)",
+                      }}
+                    >
+                      <code>{s.code}</code>
+                    </pre>
+                  )}
+                </div>
+                <div
+                  className="flex items-center justify-center overflow-hidden lg:w-1/2"
+                  style={{
+                    background: s.img
+                      ? "var(--hp-card-dark)"
+                      : "linear-gradient(135deg, #170b03, #f96411)",
+                    minHeight: 280,
+                  }}
+                >
+                  {s.img ? (
+                    <img
+                      src={s.img}
+                      alt={s.title}
+                      className="h-full w-full object-cover"
+                      style={{ opacity: 0.9 }}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="relative h-full w-full">
+                      <WatercolorBg
+                        width="100%"
+                        height="100%"
+                        className="absolute inset-0"
+                        speed={0.3}
+                        scale={0.6}
+                        octaves={3}
+                        persistence={0.5}
+                        lacunarity={2.0}
+                        driftSpeed={0.03}
+                        warpSpeed={0.06}
+                        color1="#0a0505"
+                        color2="#3399dd"
+                        colorGain={0.85}
+                        saturation={0.9}
+                        brightness={0.03}
+                      />
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <img
+                          src="/img/logo.svg"
+                          alt="Yaklang"
+                          className="h-24 w-24 sm:h-32 sm:w-32"
+                          style={{
+                            filter:
+                              "drop-shadow(0 4px 20px rgba(0,0,0,0.5)) brightness(2)",
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── OpenSource Block ──────────────────────────────────
+
+function OpenSourceBlock() {
+  const projects = [
+    {
+      name: "IRify · SSA",
+      tag: "CODE ANALYSIS",
+      desc: "基于 SSA 中间表示的静态代码分析与代码审计平台。",
+      href: LINKS.irify,
+    },
+    {
+      name: "HackSkills",
+      tag: "AI SECURITY SKILLS",
+      desc: "面向 AI Agent 的攻防技能知识库，101 个深度技能覆盖 14 个安全领域。",
+      href: LINKS.hackSkills,
+    },
+    {
+      name: "HackBenchmark",
+      tag: "AI BENCHMARK",
+      desc: "前沿 AI Agent 对真实 Web 漏洞的可复现评测基准。",
+      href: LINKS.hackBenchmark,
+    },
+    {
+      name: "YakLab",
+      tag: "VULINBOX",
+      desc: "Web 漏洞靶场实战手册：Vulinbox 通关指南。",
+      href: LINKS.yaklab,
+    },
+    {
+      name: "Memfit AI",
+      tag: "AGENT FRAMEWORK",
+      desc: "面向智能体系统的递归式双引擎混合架构。",
+      href: LINKS.memfit,
+    },
+    {
+      name: "JavaJive",
+      tag: "JAVA TOOLCHAIN",
+      desc: "纯 Go 实现的 Java 工具箱：反编译 / 类解析 / 序列化，单二进制、无需 JDK。",
+      href: "https://github.com/yaklang/javajive",
+    },
+  ];
+
+  return (
+    <section
+      id="opensource"
+      className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20"
+    >
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="OPEN SOURCE — 开源生态"
+          title="让安全知识、技能与评测形成闭环"
+          desc="产品之外，我们持续建设面向 AI 时代的知识检索、攻防技能与能力评测基础设施。"
+        />
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 sm:grid-cols-2 lg:grid-cols-3">
+          {projects.map((p, i) => (
+            <motion.a
+              key={p.name}
+              href={p.href}
+              target={p.href.startsWith("/") ? undefined : "_blank"}
+              rel={p.href.startsWith("/") ? undefined : "noreferrer"}
+              className="hp-card group flex flex-col p-6 sm:p-8"
+              style={{
+                textDecoration: "none",
+                color: "inherit",
+                minHeight: 240,
+              }}
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.08 }}
+            >
+              <p className="hp-mono" style={{ color: "var(--hp-orange)" }}>
+                {p.tag}
+              </p>
+              <h3
+                className="hp-display mt-5 text-2xl font-semibold tracking-tight"
+              >
+                {p.name}
+              </h3>
+              <p
+                className="mt-4 text-sm leading-relaxed"
+                style={{ color: "var(--hp-ink-55)" }}
+              >
+                {p.desc}
+              </p>
+              <p
+                className="hp-mono mt-auto pt-8"
+                style={{ color: "var(--hp-ink-35)", transition: "color 0.25s" }}
+              >
+                访问项目 ↗
+              </p>
+            </motion.a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Technology Block ──────────────────────────────────
+
+function TechStackBlock() {
+  const layers = [
+    {
+      k: "应用层 / APPLICATION",
+      items: [
+        "Yakit 安全平台",
+        "IRify 代码分析",
+        "Memfit AI Agent",
+        "安全技能与评测",
+      ],
+    },
+    {
+      k: "能力层 / CAPABILITY",
+      items: [
+        "MITM 引擎",
+        "Fuzzing 引擎",
+        "SSA 编译器",
+        "ReAct 引擎",
+        "Plan 引擎",
+        "RAG 知识系统",
+      ],
+    },
+    {
+      k: "基座层 / FOUNDATION",
+      items: [
+        "Yaklang CDSL",
+        "Yak VM Runtime",
+        "SSA IR",
+        "SyntaxFlow DSL",
+        "MCP Protocol",
+      ],
+    },
+  ];
+
+  return (
+    <section id="tech" className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="TECHNOLOGY — 技术体系"
+          title="一套语言，贯穿安全能力的构建与调用"
+          desc="从 Yaklang CDSL、SSA IR 与 SyntaxFlow，到扫描引擎、代码分析和智能代理，能力可以被统一描述、复用与组合。"
+        />
+        <div className="mt-10 flex flex-col gap-4 sm:mt-12">
+          {layers.map((l, i) => (
+            <motion.div
+              key={l.k}
+              className="hp-card-static p-5 sm:p-6 lg:p-7"
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.08 }}
+            >
+              <p className="hp-mono" style={{ color: "var(--hp-ink-35)" }}>
+                {l.k}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {l.items.map((it) => (
+                  <span
+                    key={it}
+                    className="rounded-full px-3 py-1.5 text-xs font-medium sm:px-4 sm:py-2 sm:text-[13px]"
+                    style={{
+                      border: "1px solid var(--hp-line)",
+                      background: "var(--hp-paper)",
+                      color: "var(--hp-ink-70)",
+                      transition: "all 0.25s ease",
+                      cursor: "default",
+                    }}
+                    onMouseEnter={(e) => {
+                      const el = e.currentTarget;
+                      el.style.borderColor = "var(--hp-orange)";
+                      el.style.color = "var(--hp-orange)";
+                    }}
+                    onMouseLeave={(e) => {
+                      const el = e.currentTarget;
+                      el.style.borderColor = "var(--hp-line)";
+                      el.style.color = "var(--hp-ink-70)";
+                    }}
+                  >
+                    {it}
+                  </span>
+                ))}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        <motion.div
+          className="relative mt-4 overflow-hidden sm:mt-5"
+          style={{ height: 160, borderRadius: 20 }}
+          {...fadeUp}
+        >
+          <WatercolorBg
+            width="100%"
+            height="100%"
+            className="absolute inset-0"
+            speed={0.4}
+            scale={0.5}
+            octaves={4}
+            persistence={0.55}
+            lacunarity={2.1}
+            driftSpeed={0.05}
+            warpSpeed={0.09}
+            color1="#170b03"
+            color2="#fc7b1c"
+            colorGain={0.85}
+            saturation={1}
+            brightness={0.02}
+          />
+          <div className="pointer-events-none absolute inset-0 flex items-end justify-between p-4 sm:p-5">
+            <span className="hp-mono" style={{ color: "rgba(250,246,239,0.5)" }}>
+              SECURITY FIELD — 安全能力基座
+            </span>
+            <span className="hp-mono" style={{ color: "rgba(250,246,239,0.5)" }}>
+              WEBGL / WATERCOLOR
+            </span>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Testimonials Block ────────────────────────────────
+
+function TestimonialsBlock() {
+  const quotes = [
+    {
+      name: "ykc",
+      org: "长亭科技",
+      text: "Yak 创造了足够的可能性，让我们可以在巨人的肩膀上发挥想象力。",
+    },
+    {
+      name: "Alex-null",
+      org: "青藤云安全",
+      text: "Yak 是目前看到的国内最优秀的安全能力底座。",
+    },
+    {
+      name: "wooluo",
+      org: "安全从业者",
+      text: "国产渗透中单兵作业工具……代替 BurpSuite 的不二首选。",
+    },
+    {
+      name: "李大壮",
+      org: "Xiecat 团队",
+      text: "成为安全领域的 Matlab。",
+    },
+    {
+      name: "key@OverSpace",
+      org: "安全从业者",
+      text: "完成了某种意义上的『大一统』。",
+    },
+    {
+      name: "国产大熊猫",
+      org: "生态共建贡献者",
+      text: "Yakit 是一款优秀的国产 web 渗透工具……像一位战友陪伴在身边。",
+    },
+  ];
+
+  return (
+    <section className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="VOICES — 用户故事"
+          title="来自安全社区的声音"
+          desc="来自一线安全从业者、安全厂商、开源贡献者的真实评价。"
+        />
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 sm:grid-cols-2 lg:grid-cols-3">
+          {quotes.map((q, i) => (
+            <motion.div
+              key={q.name}
+              className="hp-card-static p-6 sm:p-8"
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.06 }}
+            >
+              <p
+                className="text-sm leading-relaxed italic"
+                style={{ color: "var(--hp-ink-70)" }}
+              >
+                「{q.text}」
+              </p>
+              <div className="mt-5 flex items-center gap-3">
+                <div
+                  className="flex h-9 w-9 items-center justify-center rounded-full text-xs font-bold"
+                  style={{
+                    background: "var(--hp-orange)",
+                    color: "#fff",
+                  }}
+                >
+                  {q.name.charAt(0).toUpperCase()}
+                </div>
+                <div>
+                  <p className="text-sm font-semibold">{q.name}</p>
+                  <p className="text-xs" style={{ color: "var(--hp-ink-55)" }}>
+                    {q.org}
+                  </p>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Timeline Block ────────────────────────────────────
+
+function TimelineBlock() {
+  const milestones = [
+    {
+      year: "2021",
+      title: "Yakit 首次开源",
+      desc: "一次性导入完整源码，首日即具备 MITM、Web Fuzzer、Codec 等核心能力。",
+      star: true,
+    },
+    {
+      year: "2023",
+      title: "Yaklang 核心开源 · SyntaxFlow 诞生",
+      desc: "Yaklang 核心仓库正式开源，首日即发布 v1.2.0-sp6。SyntaxFlow 漏洞建模 DSL 同年落地。",
+      star: true,
+    },
+    {
+      year: "2023",
+      title: "工信部十大科技进展",
+      desc: "YAK 入选工信部信息通信领域十大科技进展，获国家级科技荣誉。",
+      star: true,
+    },
+    {
+      year: "2024",
+      title: "CDSL 教材出版 · 院士鉴定",
+      desc: "《CDSL-YAK 网络安全领域编程语言》正式出版；九位院士鉴定为「国内外首创、国际先进」。",
+      star: true,
+    },
+    {
+      year: "2025",
+      title: "AI 元年 · IRify 独立",
+      desc: "Yakit AI-Agent 落地、IRify 正式命名、aireact 框架成型。",
+      star: true,
+    },
+    {
+      year: "2026",
+      title: "产品矩阵成型",
+      desc: "IRify AI 代码审计上线、Yakit v1.4.8 发布、Yaklang 累计 14,000+ 提交。",
+      star: false,
+    },
+  ];
+
+  return (
+    <section className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="TIMELINE — 开源历程"
+          title="从一门语言到一个生态"
+          desc="Yak Project 五年持续迭代的关键里程碑。"
+        />
+        <div className="mt-10 sm:mt-12">
+          {milestones.map((m, i) => (
+            <motion.div
+              key={`${m.year}-${m.title}`}
+              className="flex gap-4 sm:gap-6"
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.08 }}
+            >
+              <div className="flex flex-col items-center">
+                <div
+                  className={`hp-timeline-dot ${m.star ? "hp-timeline-dot-star" : ""}`}
+                />
+                {i < milestones.length - 1 && (
+                  <div className="hp-timeline-line flex-1" style={{ minHeight: 40 }} />
+                )}
+              </div>
+              <div className="pb-8">
+                <p
+                  className="hp-mono"
+                  style={{ color: "var(--hp-orange)" }}
+                >
+                  {m.year}
+                </p>
+                <h4 className="mt-1 text-base font-semibold sm:text-lg">
+                  {m.title}
+                </h4>
+                <p
+                  className="mt-1 text-sm leading-relaxed"
+                  style={{ color: "var(--hp-ink-55)", maxWidth: 560 }}
+                >
+                  {m.desc}
+                </p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Partners Block ────────────────────────────────────
+
+function PartnersBlock() {
+  const partners = [
+    "亚信安全",
+    "奇安信",
+    "HackingClub",
+    "米斯特安全",
+    "云众可信",
+    "58",
+    "CTstack",
+    "E安全",
+    "嘶吼",
+    "四叶草安全",
+    "安全脉搏",
+    "智联 SRC",
+    "度小满",
+    "贝壳",
+    "快手",
+    "小米",
+    "无糖信息",
+    "三叶草",
+    "c4 安全团队",
+  ];
+
+  return (
+    <section className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="PARTNERS — 合作伙伴"
+          title="与行业共建安全生态"
+          desc="来自安全、互联网、金融等领域的合作伙伴，共同推动网络安全基础设施的发展。"
+        />
+        <div className="mt-10 flex flex-wrap gap-3 sm:mt-12">
+          {partners.map((p, i) => (
+            <motion.span
+              key={p}
+              className="rounded-full px-5 py-2.5 text-sm font-medium"
+              style={{
+                border: "1px solid var(--hp-line)",
+                background: "#fffdf9",
+                color: "var(--hp-ink-55)",
+                transition: "all 0.25s ease",
+              }}
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: (i % 10) * 0.03 }}
+              whileHover={{
+                borderColor: "rgba(244,90,12,0.5)",
+                color: "var(--hp-orange)",
+              }}
+            >
+              {p}
+            </motion.span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── About Block ───────────────────────────────────────
+
+function AboutBlock() {
+  const values = [
+    {
+      t: "开源优先",
+      d: "核心项目持续在 GitHub 开放演进，与社区共同建设。可见、可验证的代码是安全信任的基础。",
+    },
+    {
+      t: "安全融合",
+      d: "打破工具壁垒，实现能力互联互通。复杂的安全操作被抽象为可编程、可复用的能力单元。",
+    },
+    {
+      t: "AI 原生",
+      d: "让模型不止回答问题，更能调用知识、技能与工具完成任务，把 AI 深度融入安全工作流。",
+    },
+  ];
+
+  return (
+    <section id="about" className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <SectionHead
+          tag="ABOUT US — 关于我们"
+          title="做安全能力融合的长期建设者"
+          desc="万径安全是一支以开源为底色的安全技术团队，围绕 Yaklang 持续建设语言、引擎、平台与智能代理。"
+        />
+        <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 md:grid-cols-3">
+          {values.map((v, i) => (
+            <motion.div
+              key={v.t}
+              className="hp-card-static p-6 sm:p-8"
+              {...fadeUp}
+              transition={{ ...fadeUp.transition, delay: i * 0.08 }}
+            >
+              <p className="hp-mono" style={{ color: "var(--hp-orange)" }}>
+                {String(i + 1).padStart(2, "0")} /
+              </p>
+              <h3 className="hp-display mt-3 text-xl font-semibold tracking-tight">
+                {v.t}
+              </h3>
+              <p
+                className="mt-3 text-sm leading-relaxed"
+                style={{ color: "var(--hp-ink-55)" }}
+              >
+                {v.d}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+
+        <motion.div
+          className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center"
+          {...fadeUp}
+        >
+          <a href={LINKS.team} className="hp-btn-orange">
+            了解团队
+          </a>
+          <a
+            href={LINKS.github}
+            target="_blank"
+            rel="noreferrer"
+            className="hp-btn-line"
+          >
+            GitHub ↗
+          </a>
+          <a href={LINKS.download} className="hp-btn-line">
+            下载资源
+          </a>
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Vision Block ──────────────────────────────────────
+
+function VisionBlock() {
+  return (
+    <section className="px-4 py-12 sm:px-6 sm:py-16 lg:px-8 lg:py-20">
+      <div className="mx-auto" style={{ maxWidth: 1280 }}>
+        <div
+          className="hp-hero-card relative w-full"
+          style={{ aspectRatio: "16/8.6" }}
+        >
+          <WatercolorBg
+            width="100%"
+            height="100%"
+            className="absolute inset-0"
+            speed={0.4}
+            scale={0.42}
+            octaves={4}
+            persistence={0.55}
+            lacunarity={2.1}
+            driftSpeed={0.04}
+            warpSpeed={0.07}
+            color1="#150a04"
+            color2="#ee4d04"
+            colorGain={0.8}
+            saturation={0.95}
+            brightness={0.02}
+          />
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(95% 90% at 50% 50%, rgba(12,6,3,0.72), rgba(12,6,3,0.22) 70%)",
+            }}
+          />
+          <div className="pointer-events-none relative z-10 flex h-full w-full flex-col items-center justify-center gap-5 px-5 py-16 text-center sm:gap-6 sm:px-8 lg:gap-7">
+            <p
+              className="hp-mono"
+              style={{ color: "rgba(250,246,239,0.5)" }}
+            >
+              VISION — 愿景
+            </p>
+            <h2
+              className="hp-display text-2xl font-semibold tracking-tight sm:text-3xl md:text-5xl"
+              style={{ color: "#faf6ef", lineHeight: 1.35, maxWidth: 720 }}
+            >
+              <StaggeredTextClient
+                text={"做难而正确的事\n让专业安全能力触手可及"}
+                segmentBy="chars"
+                as="span"
+                delay={40}
+                duration={0.7}
+                direction="bottom"
+                blur
+                className="whitespace-pre-line"
+              />
+            </h2>
+            <p
+              className="text-sm leading-relaxed"
+              style={{
+                color: "rgba(250,246,239,0.65)",
+                maxWidth: 520,
+              }}
+            >
+              把复杂的安全操作沉淀为可编程、可复用、可由 AI
+              调用的能力单元，
+              持续拓展每一位安全从业者能够完成的事情。
+            </p>
+            <p
+              className="hp-mono"
+              style={{ color: "rgba(250,246,239,0.4)" }}
+            >
+              LANGUAGE · ENGINE · PLATFORM · AGENT
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─── Install Block (安装引导) ──────────────────────────
+
+function InstallBlock() {
+  const [copied, setCopied] = useState(false);
+  const cmd =
+    "bash <(curl -sS -L http://oss-qn.yaklang.com/install-latest-yak.sh)";
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(cmd);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <section className="px-4 py-8 sm:px-6 lg:px-8">
+      <motion.div
+        className="mx-auto flex flex-col items-center gap-4 sm:flex-row sm:justify-center sm:gap-6"
+        style={{ maxWidth: 1280 }}
+        {...fadeUp}
+      >
+        <p className="hp-mono" style={{ color: "var(--hp-ink-35)" }}>
+          QUICK INSTALL — 快速安装
+        </p>
+        <div
+          className="flex items-center gap-3 rounded-full px-5 py-2.5"
+          style={{
+            background: "var(--hp-card-dark)",
+            fontFamily: "var(--hp-font-mono)",
+            fontSize: 13,
+            color: "rgba(250,246,239,0.85)",
+          }}
+        >
+          <code className="truncate" style={{ maxWidth: 400 }}>
+            {cmd}
+          </code>
+          <button
+            onClick={handleCopy}
+            className="ml-2 cursor-pointer rounded px-2 py-1 text-xs transition-colors"
+            style={{
+              background: copied
+                ? "var(--hp-orange)"
+                : "rgba(250,246,239,0.15)",
+              color: "#fff",
+              border: "none",
+            }}
+          >
+            {copied ? "✓" : "复制"}
+          </button>
+        </div>
+      </motion.div>
+    </section>
+  );
+}
+
+// ─── Main Export ───────────────────────────────────────
+
+export function NewHomePage() {
+  return (
+    <div className="hp-root">
+      <HeroBlock />
+      <DownloadBlock />
+      <MarqueeBlock />
+      <ProductsBlock />
+      <ShowcaseBlock />
+      <OpenSourceBlock />
+      <TechStackBlock />
+      <TestimonialsBlock />
+      <TimelineBlock />
+      <PartnersBlock />
+      <AboutBlock />
+      <InstallBlock />
+      <VisionBlock />
+    </div>
+  );
+}

--- a/src/components/homepage/hero-24.tsx
+++ b/src/components/homepage/hero-24.tsx
@@ -1,0 +1,308 @@
+import { ArrowRight } from "lucide-react";
+import { motion, useReducedMotion, type Variants } from "motion/react";
+import { useEffect, useState } from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import Watercolor from "../react-bits/watercolor";
+
+// ─── dark mode 检测 ────────────────────────────────────
+function useIsDark() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    const read = () => {
+      const classes = document.documentElement.classList;
+      if (classes.contains("dark")) return true;
+      if (classes.contains("light")) return false;
+      return query.matches;
+    };
+    const update = () => setIsDark(read());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    query.addEventListener("change", update);
+    return () => {
+      observer.disconnect();
+      query.removeEventListener("change", update);
+    };
+  }, []);
+
+  return isDark;
+}
+
+// ─── 动画变体 ──────────────────────────────────────────
+const container: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.09, delayChildren: 0.08 } },
+};
+
+const item: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.7, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+const headline: Variants = {
+  hidden: { opacity: 0, y: 26, filter: "blur(10px)" },
+  show: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.85, ease: [0.22, 1, 0.36, 1] },
+  },
+};
+
+// ─── Watercolor 背景包装（SSR 安全） ──────────────────
+function WatercolorHeroField({ isDark }: { isDark: boolean }) {
+  const reduceMotion = useReducedMotion();
+  // 主体色为同色系橙色，避免 color1/color2 跨度过大产生灰/脏分层
+  const palette = isDark
+    ? {
+        color1: "#ff5e00",
+        color2: "#ff9a4d",
+        opacity: 0.75,
+      }
+    : {
+        color1: "#ff7d23",
+        color2: "#ffb380",
+        opacity: 0.85,
+      };
+
+  return (
+    <BrowserOnly fallback={<div className="absolute inset-0" style={{ background: "linear-gradient(135deg, #faf6ef, #fff0e6)" }} />}>
+      {() => (
+        <Watercolor
+          key={isDark ? "dark" : "light"}
+          width="100%"
+          height="100%"
+          speed={reduceMotion ? 0 : 0.68}
+          scale={3.2}
+          octaves={7}
+          persistence={0.55}
+          lacunarity={3.4}
+          driftSpeed={0.08}
+          warpSpeed={0.2}
+          color1={palette.color1}
+          color2={palette.color2}
+          colorGain={1.2}
+          saturation={0.3}
+          brightness={0.12}
+          opacity={palette.opacity}
+          cursorInteraction={false}
+          className="absolute inset-0 h-full w-full"
+        />
+      )}
+    </BrowserOnly>
+  );
+}
+
+export function Hero24() {
+  const isDark = useIsDark();
+
+  return (
+    <section
+      className="relative flex w-full flex-col overflow-hidden px-4 sm:px-6 lg:px-8"
+      style={{
+        background: isDark ? "#0a0503" : "var(--hp-paper, #faf6ef)",
+        marginTop: 60,
+        minHeight: "calc(100vh - 60px)",
+        height: "calc(100vh - 60px)",
+      }}
+    >
+      {/* 全屏 Watercolor WebGL 背景 —— 流动水彩科技纹理 */}
+      <div className="absolute inset-0 z-0">
+        <WatercolorHeroField isDark={isDark} />
+      </div>
+
+      {/* 左侧渐变蒙层：左边更淡透出 Watercolor，右边保留清晰纹理 */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-[1]"
+        style={{
+          background: isDark
+            ? "linear-gradient(to right, rgba(10,5,3,0.82) 0%, rgba(10,5,3,0.45) 35%, rgba(10,5,3,0.10) 65%, rgba(10,5,3,0) 100%)"
+            : "linear-gradient(to right, rgba(250,246,239,0.78) 0%, rgba(250,246,239,0.35) 35%, rgba(250,246,239,0.08) 65%, rgba(250,246,239,0) 100%)",
+        }}
+      />
+
+      {/* 底部渐变蒙层：让 banner 区域与背景平滑过渡 */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] h-[140px]"
+        style={{
+          background: isDark
+            ? "linear-gradient(to bottom, rgba(10,5,3,0) 0%, rgba(10,5,3,0.85) 60%, rgba(10,5,3,0.95) 100%)"
+            : "linear-gradient(to bottom, rgba(250,246,239,0) 0%, rgba(250,246,239,0.85) 60%, rgba(250,246,239,0.95) 100%)",
+        }}
+      />
+
+      {/* 内容层 —— 左对齐，垂直居中，最大宽度 1400px 居中 */}
+      <div
+        className="relative z-10 mx-auto flex w-full flex-1 items-center"
+        style={{ maxWidth: 1400 }}
+      >
+        <motion.div
+          variants={container}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, margin: "-80px" }}
+          className="flex flex-col items-start text-left"
+          style={{ maxWidth: 640 }}
+        >
+          {/* 状态芯片 */}
+          <motion.div
+            variants={item}
+            className="inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 text-xs font-medium backdrop-blur-md"
+            style={{
+              border: isDark
+                ? "1px solid rgba(255,255,255,0.1)"
+                : "1px solid rgba(33,26,18,0.12)",
+              background: isDark
+                ? "rgba(255,255,255,0.05)"
+                : "rgba(255,253,249,0.7)",
+              color: isDark ? "rgba(255,255,255,0.85)" : "var(--hp-ink-70, rgba(33,26,18,0.7))",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+            }}
+          >
+            <span className="relative flex h-2 w-2">
+              <span
+                className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-70"
+                style={{ background: "var(--hp-orange, #f45a0c)" }}
+              />
+              <span
+                className="relative inline-flex h-2 w-2 rounded-full"
+                style={{ background: "var(--hp-orange, #f45a0c)" }}
+              />
+            </span>
+            Yak Project — Open Source Security Infrastructure
+          </motion.div>
+
+          {/* 主标题 */}
+          <motion.h1
+            variants={headline}
+            className="hp-display mt-7 text-4xl font-semibold leading-[1.05] tracking-[-0.03em] sm:text-5xl lg:text-6xl xl:text-7xl"
+            style={{
+              color: isDark ? "#faf6ef" : "var(--hp-ink, #211a12)",
+            }}
+          >
+            Yak Project
+            <br />
+            <span style={{ color: "var(--hp-orange, #f45a0c)" }}>
+              广泛使用的开源
+            </span>
+            <br />
+            <span style={{ color: "var(--hp-orange, #f45a0c)" }}>
+              网络安全基础设施
+            </span>
+          </motion.h1>
+
+          {/* 副标题 */}
+          <motion.p
+            variants={item}
+            className="hp-display mt-6 text-lg leading-relaxed sm:text-xl lg:text-2xl"
+            style={{
+              color: isDark ? "rgba(250,246,239,0.65)" : "var(--hp-ink-55, rgba(33,26,18,0.55))",
+              maxWidth: 520,
+            }}
+          >
+            Powered by{" "}
+            <span style={{ color: "var(--hp-orange, #f45a0c)", fontWeight: 600 }}>
+              CDSL-YAK
+            </span>
+            {" — "}
+            为网络安全而生的编程语言
+          </motion.p>
+
+          {/* CTA 按钮组 */}
+          <motion.div
+            variants={item}
+            className="mt-10 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap"
+          >
+            <a
+              href="/download"
+              className="hp-btn-orange inline-flex w-full cursor-pointer items-center justify-center sm:w-auto sm:px-8 sm:py-3.5 sm:text-base"
+              style={{ textDecoration: "none" }}
+            >
+              安装 Yakit 与 Yak 语言
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </a>
+            <a
+              href="#products"
+              className="hp-btn-line inline-flex w-full cursor-pointer items-center justify-center sm:w-auto sm:px-8 sm:py-3.5 sm:text-base"
+              style={{ textDecoration: "none" }}
+            >
+              Yak Project 产品矩阵
+            </a>
+            <a
+              href="https://github.com/yaklang"
+              target="_blank"
+              rel="noreferrer"
+              className="hp-btn-line inline-flex w-full cursor-pointer items-center justify-center sm:w-auto sm:px-8 sm:py-3.5 sm:text-base"
+              style={{ textDecoration: "none" }}
+            >
+              GitHub 组织 ↗
+            </a>
+          </motion.div>
+        </motion.div>
+      </div>
+
+      {/* 底部 banner —— 关键词条（紧凑、间距相等、整体靠左） */}
+      <div className="relative z-10 w-full pb-8 pt-4 sm:pb-10">
+        <div
+          className="mx-auto flex items-center justify-start"
+          style={{ maxWidth: 1400 }}
+        >
+          {[
+            "深耕开源",
+            "可信赖",
+            "用户至上",
+            "安全基础设施",
+            "难而正确",
+          ].map((kw, i, arr) => (
+            <span key={kw} className="inline-flex items-center">
+              <motion.span
+                variants={item}
+                initial="hidden"
+                whileInView="show"
+                viewport={{ once: true }}
+                transition={{
+                  duration: 0.7,
+                  ease: [0.22, 1, 0.36, 1],
+                  delay: 0.6 + i * 0.08,
+                }}
+                className="hp-mono text-xs sm:text-sm"
+                style={{
+                  color: isDark
+                    ? "rgba(250,246,239,0.55)"
+                    : "var(--hp-ink-55, rgba(33,26,18,0.55))",
+                }}
+              >
+                {kw}
+              </motion.span>
+              {i < arr.length - 1 && (
+                <span
+                  className="hp-mono mx-4 text-xs sm:text-sm"
+                  style={{
+                    color: isDark
+                      ? "rgba(250,246,239,0.3)"
+                      : "var(--hp-ink-35, rgba(33,26,18,0.35))",
+                  }}
+                >
+                  /
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Hero24;

--- a/src/components/homepage/hero-24.tsx
+++ b/src/components/homepage/hero-24.tsx
@@ -225,7 +225,7 @@ export function Hero24() {
             className="mt-10 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap"
           >
             <a
-              href="/download"
+              href="#downloads"
               className="hp-btn-orange inline-flex w-full cursor-pointer items-center justify-center sm:w-auto sm:px-8 sm:py-3.5 sm:text-base"
               style={{ textDecoration: "none" }}
             >

--- a/src/components/homepage/homepage.scss
+++ b/src/components/homepage/homepage.scss
@@ -1,0 +1,261 @@
+/* yaklang.com 新首页 — 暖色学术风 + 橙色品牌色 */
+
+:root {
+  --hp-paper: #faf6ef;
+  --hp-ink: #211a12;
+  --hp-ink-70: rgba(33, 26, 18, 0.7);
+  --hp-ink-55: rgba(33, 26, 18, 0.55);
+  --hp-ink-35: rgba(33, 26, 18, 0.35);
+  --hp-line: rgba(33, 26, 18, 0.12);
+  --hp-orange: #f45a0c;
+  --hp-orange-deep: #c94605;
+  --hp-card-dark: #150d06;
+  --hp-font-sans: "Helvetica Neue", "PingFang SC", "Hiragino Sans GB",
+    "Noto Sans SC", "Microsoft YaHei", system-ui, sans-serif;
+  --hp-font-display: "Noto Serif SC", "Songti SC", "STSong", Georgia,
+    "Times New Roman", serif;
+  --hp-font-mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas,
+    monospace;
+}
+
+.hp-root {
+  background: var(--hp-paper);
+  color: var(--hp-ink);
+  font-family: var(--hp-font-sans);
+  -webkit-font-smoothing: antialiased;
+
+  ::selection {
+    background: var(--hp-orange);
+    color: #fff;
+  }
+}
+
+/* mono 标签 */
+.hp-mono {
+  font-family: var(--hp-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* 衬线标题 */
+.hp-display {
+  font-family: var(--hp-font-display);
+}
+
+/* ---------- Hero 卡片 ---------- */
+.hp-hero-card {
+  background: var(--hp-card-dark);
+  border-radius: 24px;
+  overflow: hidden;
+  position: relative;
+}
+
+.hp-hero-veil {
+  background: radial-gradient(
+      110% 90% at 88% 4%,
+      rgba(10, 5, 2, 0.52),
+      transparent 55%
+    ),
+    radial-gradient(
+      80% 60% at 4% 100%,
+      rgba(255, 122, 26, 0.3),
+      transparent 62%
+    ),
+    linear-gradient(
+      to top,
+      rgba(10, 5, 2, 0.72) 0%,
+      rgba(10, 5, 2, 0.25) 45%,
+      rgba(10, 5, 2, 0) 70%
+    );
+}
+
+/* 缺口 notch */
+.hp-hero-notch {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  background: var(--hp-paper);
+  border-top-left-radius: 24px;
+}
+
+.hp-hero-notch::before,
+.hp-hero-notch::after {
+  content: "";
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  background: radial-gradient(
+    circle 24px at 0 0,
+    transparent 23.5px,
+    var(--hp-paper) 24px
+  );
+}
+
+.hp-hero-notch::before {
+  top: -24px;
+  right: 0;
+}
+
+.hp-hero-notch::after {
+  left: -24px;
+  bottom: 0;
+}
+
+/* ---------- 按钮 ---------- */
+.hp-btn-paper {
+  background: rgba(250, 246, 239, 0.92);
+  color: var(--hp-ink);
+  font-weight: 600;
+  border-radius: 9999px;
+  padding: 10px 22px;
+  font-size: 13px;
+  transition: all 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--hp-orange);
+    color: #fff;
+  }
+}
+
+.hp-btn-orange {
+  background: var(--hp-orange);
+  color: #fff;
+  font-weight: 600;
+  border-radius: 9999px;
+  padding: 10px 22px;
+  font-size: 13px;
+  transition: all 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--hp-orange-deep);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 30px -8px rgba(244, 90, 12, 0.5);
+  }
+}
+
+.hp-btn-line {
+  box-shadow: inset 0 0 0 1px var(--hp-line);
+  color: var(--hp-ink);
+  font-weight: 500;
+  border-radius: 9999px;
+  padding: 10px 22px;
+  font-size: 13px;
+  background: transparent;
+  transition: all 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: inset 0 0 0 1px var(--hp-orange);
+    color: var(--hp-orange);
+  }
+}
+
+/* ---------- 卡片 ---------- */
+.hp-card {
+  background: #fffdf9;
+  border: 1px solid var(--hp-line);
+  border-radius: 18px;
+  transition: all 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+
+  &:hover {
+    border-color: rgba(244, 90, 12, 0.5);
+    box-shadow: 0 18px 50px -18px rgba(180, 100, 30, 0.25);
+    transform: translateY(-3px);
+  }
+}
+
+.hp-card-static {
+  background: #fffdf9;
+  border: 1px solid var(--hp-line);
+  border-radius: 18px;
+}
+
+/* ---------- notch 链接 ---------- */
+.hp-notch-link {
+  font-size: 14px;
+  color: var(--hp-ink-55);
+  transition: color 0.25s ease;
+  text-decoration: none;
+
+  &:hover {
+    color: var(--hp-orange);
+  }
+}
+
+/* ---------- 走马灯 ---------- */
+@keyframes hp-marquee-x {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.hp-marquee-track {
+  animation: hp-marquee-x 32s linear infinite;
+}
+
+/* ---------- Timeline ---------- */
+.hp-timeline-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--hp-orange);
+  background: var(--hp-paper);
+  flex-shrink: 0;
+}
+
+.hp-timeline-dot-star {
+  background: var(--hp-orange);
+}
+
+.hp-timeline-line {
+  width: 2px;
+  background: var(--hp-line);
+  flex-shrink: 0;
+}
+
+/* ---------- Partner Logo ---------- */
+.hp-partner-logo {
+  filter: grayscale(100%) opacity(0.45);
+  transition: filter 0.3s ease;
+
+  &:hover {
+    filter: grayscale(0%) opacity(1);
+  }
+}
+
+/* ---------- 响应式调整 ---------- */
+@media (max-width: 768px) {
+  .hp-hero-card {
+    border-radius: 16px;
+  }
+
+  .hp-hero-notch {
+    border-top-left-radius: 16px;
+  }
+
+  .hp-card {
+    border-radius: 14px;
+  }
+}

--- a/src/components/react-bits/mosaic.tsx
+++ b/src/components/react-bits/mosaic.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import { useEffect, useRef, useMemo, useCallback } from "react";
+import * as THREE from "three";
+import { cn } from "../../lib/utils";
+
+export interface MosaicProps {
+  /** Width of the component in pixels or CSS value */
+  width?: number | string;
+  /** Height of the component in pixels or CSS value */
+  height?: number | string;
+  /** Animation speed multiplier */
+  speed?: number;
+  /** Mosaic source variant */
+  variant?: "shader" | "video";
+  /** Video source URL (required when variant="video") */
+  videoSrc?: string;
+  /** Primary wave color in hex format */
+  color1?: string;
+  /** Secondary wave color in hex format */
+  color2?: string;
+  /** Accent wave color in hex format */
+  color3?: string;
+  /** Pixel/mosaic tile size (1-50) */
+  pixelSize?: number;
+  /** Mosaic border intensity (0-1) */
+  borderIntensity?: number;
+  /** Overall effect opacity (0-1) */
+  opacity?: number;
+  /** Wave intensity/amplitude (0-2) */
+  waveIntensity?: number;
+  /** Wave width/thickness (0.1-5) */
+  waveWidth?: number;
+  /** Rendering quality */
+  quality?: "low" | "medium" | "high";
+  /** Additional CSS classes */
+  className?: string;
+  /** Content to render on top of the effect */
+  children?: React.ReactNode;
+}
+
+const Mosaic: React.FC<MosaicProps> = ({
+  width = "100%",
+  height = "100%",
+  speed = 1.0,
+  variant = "shader",
+  videoSrc,
+  color1 = "#FF0033",
+  color2 = "#00FF66",
+  color3 = "#0066FF",
+  pixelSize = 10.0,
+  borderIntensity = 0.8,
+  opacity = 1.0,
+  waveIntensity = 1.0,
+  waveWidth = 1.0,
+  quality = "high",
+  className,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
+  const startTimeRef = useRef<number>(0);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const videoTextureRef = useRef<THREE.VideoTexture | null>(null);
+
+  const hexToRgb = useCallback((hex: string) => {
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return result
+      ? {
+          r: parseInt(result[1], 16) / 255,
+          g: parseInt(result[2], 16) / 255,
+          b: parseInt(result[3], 16) / 255,
+        }
+      : { r: 1, g: 0, b: 0.2 };
+  }, []);
+
+  const rgbColor1 = useMemo(() => hexToRgb(color1), [color1, hexToRgb]);
+  const rgbColor2 = useMemo(() => hexToRgb(color2), [color2, hexToRgb]);
+  const rgbColor3 = useMemo(() => hexToRgb(color3), [color3, hexToRgb]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const container = containerRef.current;
+
+    const rect = container.getBoundingClientRect();
+    const actualWidth = rect.width;
+    const actualHeight = rect.height;
+
+    const renderer = new THREE.WebGLRenderer({
+      antialias: false,
+      alpha: true,
+      powerPreference: "high-performance",
+    });
+    renderer.setClearColor(0x000000, 0);
+
+    let qualityMultiplier = 1.0;
+    if (quality === "low") qualityMultiplier = 0.5;
+    else if (quality === "medium") qualityMultiplier = 0.75;
+    else if (quality === "high") qualityMultiplier = 1.0;
+
+    const pixelRatio = Math.min(window.devicePixelRatio * qualityMultiplier, 2);
+    renderer.setSize(actualWidth, actualHeight, false);
+    renderer.setPixelRatio(pixelRatio);
+
+    renderer.domElement.style.width = "100%";
+    renderer.domElement.style.height = "100%";
+    renderer.domElement.style.display = "block";
+
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+    const bufferWidth = actualWidth * pixelRatio;
+    const bufferHeight = actualHeight * pixelRatio;
+
+    let videoTexture: THREE.VideoTexture | null = null;
+    if (variant === "video" && videoSrc) {
+      const video = document.createElement("video");
+      video.src = videoSrc;
+      video.crossOrigin = "anonymous";
+      video.loop = true;
+      video.muted = true;
+      video.playsInline = true;
+      video.play();
+      videoRef.current = video;
+
+      videoTexture = new THREE.VideoTexture(video);
+      videoTexture.minFilter = THREE.LinearFilter;
+      videoTexture.magFilter = THREE.LinearFilter;
+      videoTextureRef.current = videoTexture;
+    }
+
+    const uniforms = {
+      iTime: { value: 0 },
+      iResolution: { value: new THREE.Vector3(bufferWidth, bufferHeight, 1.0) },
+      uColor1: {
+        value: new THREE.Vector3(rgbColor1.r, rgbColor1.g, rgbColor1.b),
+      },
+      uColor2: {
+        value: new THREE.Vector3(rgbColor2.r, rgbColor2.g, rgbColor2.b),
+      },
+      uColor3: {
+        value: new THREE.Vector3(rgbColor3.r, rgbColor3.g, rgbColor3.b),
+      },
+      uPixelSize: { value: Math.max(1, Math.min(50, pixelSize)) },
+      uBorderIntensity: { value: Math.max(0, Math.min(1, borderIntensity)) },
+      uOpacity: { value: Math.max(0, Math.min(1, opacity)) },
+      uWaveIntensity: { value: Math.max(0, Math.min(2, waveIntensity)) },
+      uWaveWidth: { value: Math.max(0.1, Math.min(5, waveWidth)) },
+      uVariant: { value: variant === "video" ? 1 : 0 },
+      uVideoTexture: { value: videoTexture },
+    };
+
+    const vertexShader = `
+      void main() {
+        gl_Position = vec4(position, 1.0);
+      }
+    `;
+
+    const fragmentShader = `
+      precision mediump float;
+
+      uniform float iTime;
+      uniform vec3 iResolution;
+      uniform vec3 uColor1;
+      uniform vec3 uColor2;
+      uniform vec3 uColor3;
+      uniform float uPixelSize;
+      uniform float uBorderIntensity;
+      uniform float uOpacity;
+      uniform float uWaveIntensity;
+      uniform float uWaveWidth;
+      uniform int uVariant;
+      uniform sampler2D uVideoTexture;
+
+      float waveValue(in vec2 uv, float d, float offset) {
+        return 1.0 - smoothstep(0.0, d, distance(uv.x, 0.5 + sin(offset + uv.y * 3.0) * 0.3));
+      }
+
+      vec4 waveBackground(vec2 uv, float offset) {
+        vec2 centeredUV = uv;
+
+        float aspect = iResolution.x / iResolution.y;
+        if (aspect > 1.0) {
+          centeredUV.x = (centeredUV.x - 0.5) * aspect + 0.5;
+        } else {
+          centeredUV.y = (centeredUV.y - 0.5) / aspect + 0.5;
+        }
+
+        float d = (0.05 + abs(sin(offset * 0.2)) * 0.25 * distance(centeredUV.y, 0.5)) * uWaveWidth;
+
+        float r = waveValue(centeredUV + vec2(d * 0.25, 0.0), d, offset);
+        float g = waveValue(centeredUV - vec2(0.015, 0.005), d, offset);
+        float b = waveValue(centeredUV - vec2(d * 0.5, 0.015), d, offset);
+
+        return vec4(r, g, b, 1.0);
+      }
+
+      vec4 pixelate(vec2 fragCoord, vec4 backgroundColor) {
+        float pixelPrecision = 3.0;
+        vec2 pixel = fragCoord - vec2(ivec2(fragCoord.xy) % int(uPixelSize));
+        float precisePixel = floor(uPixelSize / pixelPrecision);
+
+        vec4 color = vec4(0.0);
+
+        for(float i = 0.0; i < pixelPrecision; i++) {
+          vec2 sampleCoord = pixel + precisePixel * i;
+          vec2 sampleUV = sampleCoord / iResolution.xy;
+
+          vec4 sourceColor;
+
+          if (uVariant == 1) {
+            sourceColor = texture2D(uVideoTexture, sampleUV);
+          } else {
+            sourceColor = waveBackground(sampleUV, iTime) * 0.3 +
+                         waveBackground(sampleUV + vec2(0.15, 0.0), -iTime * 2.0) * 0.3 +
+                         waveBackground(sampleUV + vec2(0.3, 0.0), iTime * 3.3) * 0.3 +
+                         waveBackground(sampleUV - vec2(0.2, 0.0), -iTime * 1.7) * 0.3 +
+                         waveBackground(sampleUV - vec2(0.4, 0.0), iTime * 2.5) * 0.3;
+          }
+
+          color += sourceColor;
+        }
+
+        color = color / pixelPrecision;
+
+        vec3 colorMix;
+        float colorIntensity;
+
+        if (uVariant == 1) {
+          colorMix = color.rgb;
+          colorIntensity = (color.r + color.g + color.b) / 3.0;
+        } else {
+          colorMix = color.r * uColor1 + color.g * uColor2 + color.b * uColor3;
+          colorIntensity = (color.r + color.g + color.b) / 3.0;
+          colorMix *= uWaveIntensity;
+        }
+
+        color = vec4(colorMix, colorIntensity);
+
+        vec4 border = vec4(0.0);
+        if ((int(fragCoord.y) % int(uPixelSize) == int(0)) ||
+            (int(fragCoord.x) % int(uPixelSize) == int(0))) {
+          color.rgb -= vec3(uBorderIntensity * 0.3);
+        }
+
+        return color;
+      }
+
+      void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+        vec2 uv = fragCoord / iResolution.xy;
+
+        vec4 background;
+
+        if (uVariant == 1) {
+          background = texture2D(uVideoTexture, uv);
+        } else {
+          background = waveBackground(uv, iTime) * 0.3 +
+                      waveBackground(uv + vec2(0.15, 0.0), -iTime * 2.0) * 0.3 +
+                      waveBackground(uv + vec2(0.3, 0.0), iTime * 3.3) * 0.3 +
+                      waveBackground(uv - vec2(0.2, 0.0), -iTime * 1.7) * 0.3 +
+                      waveBackground(uv - vec2(0.4, 0.0), iTime * 2.5) * 0.3;
+        }
+
+        vec4 mosaicColor = pixelate(fragCoord, background);
+
+        fragColor = vec4(mosaicColor.rgb, mosaicColor.a * uOpacity);
+      }
+
+      void main() {
+        vec4 color = vec4(0.0);
+        mainImage(color, gl_FragCoord.xy);
+        gl_FragColor = color;
+      }
+    `;
+
+    const material = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+    });
+
+    const geometry = new THREE.PlaneGeometry(2, 2);
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    startTimeRef.current = performance.now();
+    let lastTime = startTimeRef.current;
+
+    const animate = (currentTime: number) => {
+      rafRef.current = requestAnimationFrame(animate);
+
+      if (currentTime - lastTime < 16) return;
+      lastTime = currentTime;
+
+      const elapsed = (currentTime - startTimeRef.current) * 0.001 * speed;
+      uniforms.iTime.value = elapsed;
+
+      renderer.render(scene, camera);
+    };
+
+    rafRef.current = requestAnimationFrame(animate);
+
+    const handleResize = () => {
+      const newRect = container.getBoundingClientRect();
+      const newWidth = newRect.width;
+      const newHeight = newRect.height;
+
+      renderer.setSize(newWidth, newHeight, false);
+
+      const newBufferWidth = newWidth * pixelRatio;
+      const newBufferHeight = newHeight * pixelRatio;
+      uniforms.iResolution.value.set(newBufferWidth, newBufferHeight, 1.0);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      cancelAnimationFrame(rafRef.current);
+      scene.remove(mesh);
+      geometry.dispose();
+      material.dispose();
+      renderer.dispose();
+      if (renderer.domElement && renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
+      if (videoRef.current) {
+        videoRef.current.pause();
+        videoRef.current = null;
+      }
+      if (videoTextureRef.current) {
+        videoTextureRef.current.dispose();
+        videoTextureRef.current = null;
+      }
+    };
+  }, [
+    speed,
+    variant,
+    videoSrc,
+    pixelSize,
+    borderIntensity,
+    opacity,
+    waveIntensity,
+    waveWidth,
+    quality,
+    rgbColor1,
+    rgbColor2,
+    rgbColor3,
+  ]);
+
+  const widthStyle = typeof width === "number" ? `${width}px` : width;
+  const heightStyle = typeof height === "number" ? `${height}px` : height;
+
+  return (
+    <div
+      className={cn("relative overflow-hidden", className)}
+      style={{
+        width: widthStyle,
+        height: heightStyle,
+      }}
+    >
+      <div ref={containerRef} className="absolute inset-0" />
+      {children && (
+        <div className="relative z-10 w-full h-full pointer-events-none">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+Mosaic.displayName = "Mosaic";
+
+export default Mosaic;

--- a/src/components/react-bits/staggered-text.tsx
+++ b/src/components/react-bits/staggered-text.tsx
@@ -1,0 +1,234 @@
+import React, {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useImperativeHandle,
+  forwardRef,
+} from "react";
+import { motion, Transition, Easing } from "motion/react";
+
+type MotionStyle = Record<string, string | number>;
+type SegmentBy = "chars" | "words" | "lines";
+type StaggerDirection = "forward" | "reverse" | "center";
+
+export interface StaggeredTextHandle {
+  replay: () => void;
+  exit: () => void;
+}
+
+export interface StaggeredTextProps {
+  text: string;
+  className?: string;
+  as?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+  segmentBy?: SegmentBy;
+  separator?: string;
+  delay?: number;
+  duration?: number;
+  easing?: Easing | Easing[];
+  threshold?: number;
+  rootMargin?: string;
+  direction?: "top" | "bottom" | "left" | "right";
+  blur?: boolean;
+  from?: MotionStyle;
+  to?: MotionStyle | MotionStyle[];
+  staggerDirection?: StaggerDirection;
+  respectReducedMotion?: boolean;
+  exitOnScrollOut?: boolean;
+  onAnimationComplete?: () => void;
+  onExitComplete?: () => void;
+}
+
+const buildKeyframes = (
+  from: MotionStyle,
+  steps: MotionStyle[],
+): Record<string, Array<string | number>> => {
+  const keys = new Set<string>([
+    ...Object.keys(from),
+    ...steps.flatMap((step) => Object.keys(step)),
+  ]);
+  const keyframes: Record<string, Array<string | number>> = {};
+  keys.forEach((key) => {
+    keyframes[key] = [from[key], ...steps.map((step) => step[key])];
+  });
+  return keyframes;
+};
+
+const StaggeredText = forwardRef<StaggeredTextHandle, StaggeredTextProps>(
+  (
+    {
+      text,
+      className = "",
+      as = "p",
+      segmentBy = "words",
+      separator,
+      delay = 80,
+      duration = 0.6,
+      easing = (t: number) => t,
+      threshold = 0.1,
+      rootMargin = "0px",
+      direction = "top",
+      blur = true,
+      from,
+      to,
+      staggerDirection = "forward",
+      respectReducedMotion = true,
+      exitOnScrollOut = false,
+      onAnimationComplete,
+      onExitComplete,
+    },
+    ref,
+  ) => {
+    const rootRef = useRef<HTMLElement | null>(null);
+    const [hasEnteredView, setHasEnteredView] = useState<boolean>(false);
+    const [isExiting, setIsExiting] = useState<boolean>(false);
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(false);
+
+    useEffect(() => {
+      if (!respectReducedMotion) return;
+      const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      setPrefersReducedMotion(mediaQuery.matches);
+      const handleChange = (e: MediaQueryListEvent) => {
+        setPrefersReducedMotion(e.matches);
+      };
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }, [respectReducedMotion]);
+
+    useImperativeHandle(ref, () => ({
+      replay: () => {
+        setIsExiting(false);
+        setHasEnteredView(false);
+        requestAnimationFrame(() => { setHasEnteredView(true); });
+      },
+      exit: () => { setIsExiting(true); },
+    }));
+
+    useEffect(() => {
+      if (!rootRef.current) return;
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setHasEnteredView(true);
+            setIsExiting(false);
+            if (!exitOnScrollOut && rootRef.current) {
+              observer.unobserve(rootRef.current);
+            }
+          } else if (exitOnScrollOut && hasEnteredView) {
+            setIsExiting(true);
+          }
+        },
+        { threshold, rootMargin },
+      );
+      observer.observe(rootRef.current);
+      return () => observer.disconnect();
+    }, [threshold, rootMargin, exitOnScrollOut, hasEnteredView]);
+
+    const defaultFrom = useMemo<MotionStyle>(() => {
+      const base: MotionStyle = { opacity: 0 };
+      if (direction === "top" || direction === "bottom") {
+        base.y = direction === "top" ? -40 : 40;
+      } else {
+        base.x = direction === "left" ? -40 : 40;
+      }
+      if (blur) { base.filter = "blur(10px)"; }
+      return base;
+    }, [direction, blur]);
+
+    const defaultTo = useMemo<MotionStyle[]>(() => {
+      const axisKey = direction === "left" || direction === "right" ? "x" : "y";
+      if (!blur) {
+        return [{ opacity: 1, [axisKey]: 0 }];
+      }
+      const overshoot = direction === "top" || direction === "left" ? 5 : -5;
+      return [
+        { opacity: 0.7, [axisKey]: overshoot, filter: "blur(5px)" },
+        { opacity: 1, [axisKey]: 0, filter: "blur(0px)" },
+      ];
+    }, [direction, blur]);
+
+    const fromSnapshot = useMemo<MotionStyle>(() => from ?? defaultFrom, [from, defaultFrom]);
+    const toSnapshots = useMemo<MotionStyle[]>(() => {
+      if (!to) return defaultTo;
+      return Array.isArray(to) ? to : [to];
+    }, [to, defaultTo]);
+
+    const stepCount = toSnapshots.length + 1;
+    const times = useMemo(
+      () => Array.from({ length: stepCount }, (_, i) =>
+        stepCount === 1 ? 0 : i / (stepCount - 1)),
+      [stepCount],
+    );
+
+    const { rowsSegments, totalSegments } = useMemo(() => {
+      if (!text) return { rowsSegments: [] as string[][], totalSegments: 0 };
+      const rows = separator && separator.length > 0
+        ? text.split(separator) : text.split(/\r?\n/);
+      const rowsSegments: string[][] = rows.map((row) => {
+        switch (segmentBy) {
+          case "chars": return row.split("");
+          case "lines": return [row];
+          case "words": default: return row.split(" ");
+        }
+      });
+      const total = rowsSegments.reduce((sum, rowSegs) => sum + rowSegs.length, 0);
+      return { rowsSegments, totalSegments: total };
+    }, [text, segmentBy, separator]);
+
+    if (!text) return null;
+    const animateKeyframes = buildKeyframes(fromSnapshot, toSnapshots);
+    let globalIndexCounter = 0;
+    const hasMultipleRows = rowsSegments.length > 1;
+
+    const getStaggerDelay = (index: number, total: number): number => {
+      if (prefersReducedMotion) return 0;
+      switch (staggerDirection) {
+        case "reverse": return ((total - 1 - index) * delay) / 1000;
+        case "center": {
+          const middle = (total - 1) / 2;
+          return (Math.abs(index - middle) * delay) / 1000;
+        }
+        case "forward": default: return (index * delay) / 1000;
+      }
+    };
+
+    const Wrapper = as;
+    return (
+      <Wrapper
+        ref={rootRef as React.RefObject<HTMLParagraphElement>}
+        className={`staggered-text ${hasMultipleRows || segmentBy === "lines" ? "block" : "flex flex-wrap"} whitespace-pre-wrap ${className}`}
+      >
+        {rowsSegments.map((rowSegments, rowIndex) => (
+          <React.Fragment key={`row-${rowIndex}`}>
+            {rowSegments.map((segment, rowSegIndex) => {
+              const globalIndex = globalIndexCounter++;
+              const isLast = globalIndex === totalSegments - 1;
+              const transition: Transition = prefersReducedMotion
+                ? { duration: 0.01, delay: 0 }
+                : { duration, times, delay: getStaggerDelay(globalIndex, totalSegments), ease: easing };
+              return (
+                <motion.span
+                  key={`seg-${rowIndex}-${rowSegIndex}`}
+                  initial={fromSnapshot}
+                  animate={isExiting ? fromSnapshot : hasEnteredView ? animateKeyframes : fromSnapshot}
+                  transition={transition}
+                  onAnimationComplete={
+                    isLast ? () => { isExiting ? onExitComplete?.() : onAnimationComplete?.(); } : undefined
+                  }
+                  style={{ display: segmentBy === "lines" ? "block" : "inline-block", willChange: "transform, filter, opacity" }}
+                >
+                  {segmentBy === "chars" ? (segment === " " ? "\u00A0" : segment) : segment}
+                  {segmentBy === "words" && rowSegIndex < rowSegments.length - 1 && "\u00A0"}
+                </motion.span>
+              );
+            })}
+            {rowIndex < rowsSegments.length - 1 && segmentBy !== "lines" && <br key={`br-${rowIndex}`} />}
+          </React.Fragment>
+        ))}
+      </Wrapper>
+    );
+  },
+);
+
+StaggeredText.displayName = "StaggeredText";
+export default StaggeredText;

--- a/src/components/react-bits/watercolor.css
+++ b/src/components/react-bits/watercolor.css
@@ -1,0 +1,17 @@
+.watercolor-container {
+  position: relative;
+  overflow: hidden;
+}
+
+.watercolor-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.watercolor-content {
+  position: relative;
+  z-index: 10;
+  pointer-events: none;
+}

--- a/src/components/react-bits/watercolor.tsx
+++ b/src/components/react-bits/watercolor.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import React, { useRef, useMemo, useCallback, useState } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import "./watercolor.css";
+
+export interface WatercolorProps {
+  /** Container width */
+  width?: string | number;
+  /** Container height */
+  height?: string | number;
+  /** Additional CSS classes */
+  className?: string;
+  /** Content rendered above the effect */
+  children?: React.ReactNode;
+  /** Animation speed multiplier */
+  speed?: number;
+  /** Pattern scale / zoom */
+  scale?: number;
+  /** Number of noise octaves (1-8) */
+  octaves?: number;
+  /** Amplitude decay per octave */
+  persistence?: number;
+  /** Frequency multiplier per octave */
+  lacunarity?: number;
+  /** Primary flow drift speed */
+  driftSpeed?: number;
+  /** Secondary warp drift speed */
+  warpSpeed?: number;
+  /** First color hex */
+  color1?: string;
+  /** Second color hex */
+  color2?: string;
+  /** Color intensity multiplier */
+  colorGain?: number;
+  /** Saturation adjustment */
+  saturation?: number;
+  /** Brightness offset */
+  brightness?: number;
+  /** Master opacity */
+  opacity?: number;
+  /** Enable cursor interaction to intensify warp and contrast near pointer */
+  cursorInteraction?: boolean;
+  /** Cursor effect strength multiplier (0–3) */
+  cursorIntensity?: number;
+}
+
+const VERTEX_SHADER = `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision highp float;
+
+uniform float uTime;
+uniform vec2 uRes;
+uniform float uSpeed;
+uniform float uScale;
+uniform int uOctaves;
+uniform float uPersist;
+uniform float uLacun;
+uniform float uDrift;
+uniform float uWarp;
+uniform vec3 uCol1;
+uniform vec3 uCol2;
+uniform float uGain;
+uniform float uSat;
+uniform float uBright;
+uniform float uAlpha;
+uniform vec2 uPointer;
+uniform float uCursorActive;
+uniform float uCursorIntensity;
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(41.713, 83.457))) * 35718.549);
+}
+
+float vnoise(vec2 p) {
+  vec2 g = floor(p);
+  vec2 f = fract(p);
+  vec2 w = f * f * (3.0 - 2.0 * f);
+
+  float tl = hash(g);
+  float tr = hash(g + vec2(1.0, 0.0));
+  float bl = hash(g + vec2(0.0, 1.0));
+  float br = hash(g + vec2(1.0, 1.0));
+
+  return mix(mix(tl, tr, w.x), mix(bl, br, w.x), w.y);
+}
+
+float layers(vec2 p) {
+  float total = 0.0;
+  float amp = 0.5;
+  float angle = 0.47;
+  float ca = cos(angle), sa = sin(angle);
+  mat2 bend = mat2(ca, -sa, sa, ca);
+
+  for (int k = 0; k < 8; k++) {
+    if (k >= uOctaves) break;
+    total += amp * vnoise(p);
+    p = bend * p * uLacun + 193.7;
+    amp *= uPersist;
+  }
+
+  return total;
+}
+
+void main() {
+  vec2 coord = (gl_FragCoord.xy * 2.0 - uRes) / uRes.y;
+  coord *= uScale;
+
+  float t = uTime * uSpeed;
+
+  vec2 pointerCoord = (uPointer * 2.0 - 1.0) * vec2(uRes.x / uRes.y, 1.0) * uScale;
+  float cursorDist = length(coord - pointerCoord);
+  float cursorInfluence = smoothstep(0.8, 0.0, cursorDist) * uCursorActive * uCursorIntensity;
+
+  vec2 cursorDir = normalize(coord - pointerCoord + 0.001);
+  vec2 warpedCoord = coord + cursorDir * cursorInfluence * 0.12;
+
+  float q = layers(warpedCoord + t * uDrift);
+  float r = layers(warpedCoord + q * (1.0 + cursorInfluence * 0.08) + t * uWarp);
+
+  float blend = r * uGain;
+  vec3 raw = mix(uCol1, uCol2, smoothstep(0.3, 0.7, blend));
+
+  float luma = dot(raw, vec3(0.299, 0.587, 0.114));
+  vec3 col = mix(vec3(luma), raw, uSat) + uBright;
+  col = clamp(col, 0.0, 1.0);
+
+  gl_FragColor = vec4(col, uAlpha);
+}
+`;
+
+function parseHexColor(hex: string): [number, number, number] {
+  const match = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!match) return [0, 0, 0];
+  return [
+    parseInt(match[1], 16) / 255,
+    parseInt(match[2], 16) / 255,
+    parseInt(match[3], 16) / 255,
+  ];
+}
+
+interface WatercolorSceneProps {
+  speed: number;
+  scale: number;
+  octaves: number;
+  persistence: number;
+  lacunarity: number;
+  driftSpeed: number;
+  warpSpeed: number;
+  col1Rgb: [number, number, number];
+  col2Rgb: [number, number, number];
+  colorGain: number;
+  saturation: number;
+  brightness: number;
+  opacity: number;
+  pointer: [number, number];
+  cursorInteraction: boolean;
+  cursorIntensity: number;
+}
+
+const WatercolorScene: React.FC<WatercolorSceneProps> = ({
+  speed,
+  scale,
+  octaves,
+  persistence,
+  lacunarity,
+  driftSpeed,
+  warpSpeed,
+  col1Rgb,
+  col2Rgb,
+  colorGain,
+  saturation,
+  brightness,
+  opacity,
+  pointer,
+  cursorInteraction,
+  cursorIntensity,
+}) => {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const { size, viewport } = useThree();
+  const smoothPointer = useRef(new THREE.Vector2(0.5, 0.5));
+
+  const uniforms = useMemo(
+    () => ({
+      uTime: { value: 0 },
+      uRes: { value: new THREE.Vector2(1, 1) },
+      uSpeed: { value: 1 },
+      uScale: { value: 1 },
+      uOctaves: { value: 6 },
+      uPersist: { value: 0.6 },
+      uLacun: { value: 2.0 },
+      uDrift: { value: 0.1 },
+      uWarp: { value: 0.3 },
+      uCol1: { value: new THREE.Vector3(0.1, 0.1, 0.1) },
+      uCol2: { value: new THREE.Vector3(0.9, 0.9, 0.9) },
+      uGain: { value: 0.95 },
+      uSat: { value: 0.7 },
+      uBright: { value: 0.1 },
+      uAlpha: { value: 1 },
+      uPointer: { value: new THREE.Vector2(0.5, 0.5) },
+      uCursorActive: { value: 0 },
+      uCursorIntensity: { value: 1 },
+    }),
+    [],
+  );
+
+  useFrame((state, delta) => {
+    if (!meshRef.current) return;
+    const mat = meshRef.current.material as THREE.ShaderMaterial;
+
+    mat.uniforms.uTime.value = state.clock.elapsedTime;
+    mat.uniforms.uRes.value.set(
+      size.width * viewport.dpr,
+      size.height * viewport.dpr,
+    );
+    mat.uniforms.uSpeed.value = speed;
+    mat.uniforms.uScale.value = scale;
+    mat.uniforms.uOctaves.value = octaves;
+    mat.uniforms.uPersist.value = persistence;
+    mat.uniforms.uLacun.value = lacunarity;
+    mat.uniforms.uDrift.value = driftSpeed;
+    mat.uniforms.uWarp.value = warpSpeed;
+    mat.uniforms.uCol1.value.set(...col1Rgb);
+    mat.uniforms.uCol2.value.set(...col2Rgb);
+    mat.uniforms.uGain.value = colorGain;
+    mat.uniforms.uSat.value = saturation;
+    mat.uniforms.uBright.value = brightness;
+    mat.uniforms.uAlpha.value = opacity;
+    mat.uniforms.uCursorActive.value = cursorInteraction ? 1 : 0;
+    mat.uniforms.uCursorIntensity.value = cursorIntensity;
+
+    const ease = 1 - Math.exp(-delta / 0.15);
+    smoothPointer.current.x += (pointer[0] - smoothPointer.current.x) * ease;
+    smoothPointer.current.y += (pointer[1] - smoothPointer.current.y) * ease;
+    mat.uniforms.uPointer.value.set(
+      smoothPointer.current.x,
+      smoothPointer.current.y,
+    );
+  });
+
+  return (
+    <mesh ref={meshRef}>
+      <planeGeometry args={[2, 2]} />
+      <shaderMaterial
+        vertexShader={VERTEX_SHADER}
+        fragmentShader={FRAGMENT_SHADER}
+        uniforms={uniforms}
+        transparent
+      />
+    </mesh>
+  );
+};
+
+const Watercolor: React.FC<WatercolorProps> = ({
+  width = "100%",
+  height = "100%",
+  className = "",
+  children,
+  speed = 0.6,
+  scale = 0.6,
+  octaves = 6,
+  persistence = 0.6,
+  lacunarity = 2.4,
+  driftSpeed = 0.04,
+  warpSpeed = 0.08,
+  color1 = "#0a0a0a",
+  color2 = "#e0e0e0",
+  colorGain = 1,
+  saturation = 0,
+  brightness = 0.15,
+  opacity = 1,
+  cursorInteraction = false,
+  cursorIntensity = 1,
+}) => {
+  const col1Rgb = useMemo(() => parseHexColor(color1), [color1]);
+  const col2Rgb = useMemo(() => parseHexColor(color2), [color2]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pointer, setPointer] = useState<[number, number]>([0.5, 0.5]);
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!cursorInteraction) return;
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const nx = (e.clientX - rect.left) / rect.width;
+      const ny = 1 - (e.clientY - rect.top) / rect.height;
+      setPointer([nx, ny]);
+    },
+    [cursorInteraction],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className={`watercolor-container ${className}`}
+      style={{ width, height }}
+      onPointerMove={handlePointerMove}
+    >
+      <Canvas
+        className="watercolor-canvas"
+        orthographic
+        camera={{
+          position: [0, 0, 1],
+          zoom: 1,
+          left: -1,
+          right: 1,
+          top: 1,
+          bottom: -1,
+        }}
+        gl={{ antialias: true, alpha: true }}
+      >
+        <WatercolorScene
+          speed={speed}
+          scale={scale}
+          octaves={octaves}
+          persistence={persistence}
+          lacunarity={lacunarity}
+          driftSpeed={driftSpeed}
+          warpSpeed={warpSpeed}
+          col1Rgb={col1Rgb}
+          col2Rgb={col2Rgb}
+          colorGain={colorGain}
+          saturation={saturation}
+          brightness={brightness}
+          opacity={opacity}
+          pointer={pointer}
+          cursorInteraction={cursorInteraction}
+          cursorIntensity={cursorIntensity}
+        />
+      </Canvas>
+      {children && <div className="watercolor-content">{children}</div>}
+    </div>
+  );
+};
+
+Watercolor.displayName = "Watercolor";
+
+export default Watercolor;

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -29,6 +29,17 @@
 
   --base-font-color: #1e1f23;
   --base-theme-color: #ff7d23;
+
+  /* 新首页暖色学术风全局变量 */
+  --hp-paper: #faf6ef;
+  --hp-ink: #211a12;
+  --hp-ink-70: rgba(33, 26, 18, 0.7);
+  --hp-ink-55: rgba(33, 26, 18, 0.55);
+  --hp-ink-35: rgba(33, 26, 18, 0.35);
+  --hp-line: rgba(33, 26, 18, 0.12);
+  --hp-orange: #f45a0c;
+  --hp-orange-deep: #c94605;
+  --hp-card-dark: #150d06;
 }
 
 .docusaurus-highlight-code-line {
@@ -40,12 +51,15 @@
 
 #__docusaurus {
   margin: 0 auto;
+  min-height: 100vh;
+  background: var(--hp-paper, #faf6ef);
 }
 
 html,
 body {
   scroll-behavior: auto;
   // min-width: 768px;
+  background: var(--hp-paper, #faf6ef);
 }
 
 $REM: 16;
@@ -58,6 +72,7 @@ $max-width: REM(8000);
   max-width: $max-width;
   margin: 0 auto;
   width: 100%;
+  background: var(--hp-paper, #faf6ef);
   // 注意：不要在这里加 min-width。
   // 首页按视口等比缩放根字号(rem)自适应，其布局宽度由 .home-container 自带的
   // min-width 约束；而文档/博客根字号固定 16px，若此处用 rem 的 min-width 会被
@@ -84,8 +99,11 @@ $max-width: REM(8000);
 // 切勿给共同祖先 docRoot 加 padding-top：那会和 .sidebar 自带的 padding-top 叠加，
 //   导致侧栏顶部凭空多出一个导航栏高度的空白(搜索框被压低一截)。
 html.docs-wrapper {
+  background: var(--hp-paper, #faf6ef);
+
   [class*="docMainContainer_"] {
     padding-top: var(--ifm-navbar-height);
+    background: var(--hp-paper, #faf6ef);
   }
 
   // 修复：固定导航栏下，短页面(如各章概述落地页)左侧目录顶到导航栏上方的 BUG。

--- a/src/css/navbar.scss
+++ b/src/css/navbar.scss
@@ -2,10 +2,11 @@
   width: 100%;
   // 使用固定 px 高度，避免首页根字号缩放时导航栏过小不可点
   height: 60px;
-  // 不透明白底，避免下层侧栏/正文内容透出造成"遮挡/重叠"错觉
-  // 用 !important 兜底：dev / prod 下样式注入顺序不同，避免被 Infima 同特异性规则覆盖成透明
-  background-color: #ffffff !important;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06), 0 2px 8px rgba(0, 0, 0, 0.04);
+  // 暖色纸感半透明背景 + 毛玻璃：与首页和文档页的全局暖色背景保持一致
+  background: rgba(250, 246, 239, 0.92) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 1px 0 rgba(33, 26, 18, 0.08);
   position: fixed;
   top: 0;
   left: 0;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,193 +1,50 @@
-import React, { useState, useEffect, useLayoutEffect } from "react";
-// import clsx from "clsx";
+import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
-// import Link from "@docusaurus/Link";
+import Head from "@docusaurus/Head";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-// import styles from "./index.module.css";
-// import TypeIt from "typeit-react";
-// import Tilt from "react-parallax-tilt";
-// import { Typography } from "antd";
-// import { DoubleRightOutlined, FireFilled } from "@ant-design/icons";
-// import { MainPageContent } from "../components/MainPageContent";
-import { HomePage } from "../components/Home";
-
-// const { Paragraph, Text } = Typography;
-
-// function HomepageHeader() {
-//     const { siteConfig } = useDocusaurusContext();
-//     // 设置 BG
-//     const [bg, setBg] = useState();
-
-//     useEffect(() => {
-//         var m = require("../particles-bg");
-//         setBg(m);
-//     }, []);
-
-//     return (
-//         <Tilt
-//             tiltEnable={true}
-//             tiltReverse={false}
-//             tiltMaxAngleX={10}
-//             tiltMaxAngleY={10}
-//         >
-//             <header
-//                 className={clsx("hero hero--primary", styles.heroBanner)}
-//                 style={{ paddingTop: 8, paddingBottom: 8 }}
-//             >
-//                 {bg && new bg.default({ type: "circle", bg: true }).render()}
-//                 <div className="container" style={{}}>
-//                     <Space>
-//                         <div style={{ marginRight: 60 }}>
-//                             <h1 style={{ fontSize: 40, color: "#fff" }}>
-//                                 {siteConfig.title}
-//                             </h1>
-//                             <p className="hero__subtitle">
-//                                 {siteConfig.tagline}
-//                             </p>
-//                             <div className={styles.buttons}>
-//                                 <Link
-//                                     className="button button--secondary button--lg"
-//                                     to="/docs/intro"
-//                                     style={{ width: 400 }}
-//                                 >
-//                                     <Paragraph style={{ marginBottom: 0 }}>
-//                                         <Text
-//                                             delete={true}
-//                                             style={{ color: "red" }}
-//                                         >
-//                                             北半球
-//                                         </Text>{" "}
-//                                         <Text mark={true}>最强</Text> Web
-//                                         安全研发脚本语言
-//                                     </Paragraph>
-//                                 </Link>
-//                                 <br />
-//                             </div>
-//                             <Space style={{ marginTop: 18 }}>
-//                                 <div className={styles.buttons}>
-//                                     <Button type={"primary"} size={"large"}>
-//                                         <Link to={"/docs/intro"}>
-//                                             <strong>
-//                                                 快速开始 <FireFilled />
-//                                             </strong>
-//                                         </Link>
-//                                     </Button>
-//                                 </div>
-//                                 <div>
-//                                     <Button
-//                                         type={"link"}
-//                                         size={"large"}
-//                                         ghost={true}
-//                                         style={{ color: "white" }}
-//                                         className={styles.quickStart}
-//                                     >
-//                                         <Link
-//                                             to={
-//                                                 "/api-manual/yakexamples/first_servicescan"
-//                                             }
-//                                         >
-//                                             <strong>
-//                                                 基础教程 <DoubleRightOutlined />
-//                                             </strong>
-//                                         </Link>
-//                                     </Button>
-//                                 </div>
-//                             </Space>
-//                             <br />
-//                             <Space style={{ marginTop: 8 }}>
-//                                 for
-//                                 <div style={{ minWidth: 110, fontWight: 400 }}>
-//                                     <TypeIt
-//                                         options={{ loop: true, loopDelay: 0 }}
-//                                         getBeforeInit={(ins) => {
-//                                             ins.type("黑客")
-//                                                 .pause(1200)
-//                                                 .delete(2)
-//                                                 .type("白帽子")
-//                                                 .pause(1200)
-//                                                 .delete(3)
-//                                                 .type("安全工程师")
-//                                                 .pause(1200)
-//                                                 .delete(5)
-//                                                 .type("安全运营人员")
-//                                                 .pause(1200)
-//                                                 .delete(6)
-//                                                 .type("渗透测试工程师")
-//                                                 .pause(1200)
-//                                                 .delete(7)
-//                                                 .type("安全服务提供商")
-//                                                 .pause(1200)
-//                                                 .delete(7);
-//                                             return ins;
-//                                         }}
-//                                     />
-//                                 </div>
-//                             </Space>
-//                         </div>
-//                         <Image
-//                             preview={false}
-//                             height={330}
-//                             width={330}
-//                             src={"/img/yaklogo.png"}
-//                         />
-//                     </Space>
-//                 </div>
-//             </header>
-//         </Tilt>
-//     );
-// }
+import { NewHomePage } from "../components/homepage/NewHomePage";
 
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   const [isShow, setIsShow] = useState(false);
-  useEffect(() => {
-    // 首页采用固定 REM 布局（设计基准宽度 ~1232px）。
-    // 通过按视口等比缩放根字号，使整页布局在大小屏/移动端等比适配，
-    // 因所有尺寸（含 min-width）均为 rem，缩放后不会溢出也不会错位。
-    const DESIGN_WIDTH = 1232;
-    const applyRootFontSize = () => {
-      const w =
-        window.innerWidth || document.documentElement.clientWidth || DESIGN_WIDTH;
-      const fs = w >= DESIGN_WIDTH ? 16 : (16 * w) / DESIGN_WIDTH;
-      document.documentElement.style.fontSize = fs + "px";
-      document.body.style.fontSize = fs + "px";
-    };
-    applyRootFontSize();
-    setIsShow(true);
-    const evt =
-      "onorientationchange" in window ? "orientationchange" : "resize";
-    window.addEventListener(evt, applyRootFontSize);
-    return () => {
-      window.removeEventListener(evt, applyRootFontSize);
-      // 离开首页时恢复默认根字号，避免影响文档等其它页面
-      document.documentElement.style.fontSize = "";
-      document.body.style.fontSize = "";
-    };
-  }, []);
 
   useEffect(() => {
-    document.getElementsByTagName("html")[0].style.scrollBehavior = "smooth";
-    document.getElementsByTagName("body")[0].style.scrollBehavior = "smooth";
-  }, []);
-  useEffect(() => {
-    window.onbeforeunload = () => {
-      document.getElementsByTagName("html")[0].style.scrollBehavior = "auto";
-      document.getElementsByTagName("body")[0].style.scrollBehavior = "auto";
-    };
+    setIsShow(true);
   }, []);
 
   return (
     <>
+      <Head>
+        <title>Yak Project — 广泛使用的开源网络安全基础设施</title>
+        <meta
+          name="description"
+          content="Yak Project 以 CDSL-YAK 领域编程语言为内核，辐射 Yakit 安全测试平台、IRify 代码审计、Memfit AI 智能体与 JavaJive Java 工具链的完整网络安全技术体系。"
+        />
+        <meta
+          name="keywords"
+          content="Yak,Yaklang,Yakit,IRify,SSA,SyntaxFlow,Memfit AI,网络安全,渗透测试,MITM,Web Fuzzer,代码审计,SAST,安全工具,BurpSuite替代,CDSL,领域编程语言,开源安全"
+        />
+        <meta property="og:title" content="Yak Project — 广泛使用的开源网络安全基础设施" />
+        <meta
+          property="og:description"
+          content="CDSL-YAK 领域编程语言为内核，Yakit 安全测试平台、IRify 代码审计、Memfit AI 智能体——从语言到平台的完整安全技术栈。"
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://yaklang.com" />
+        <meta property="og:image" content="https://yaklang.com/img/logo.png" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content="Yak Project — 开源网络安全基础设施" />
+        <meta
+          name="twitter:description"
+          content="以 CDSL-YAK 为内核的完整网络安全技术体系：Yakit · IRify · Memfit AI · JavaJive"
+        />
+      </Head>
       {isShow && (
         <Layout
-          title={`Yak Language ${siteConfig.title}`}
-          description="Web安全能力研发最强语言"
+          title={`Yak Project — ${siteConfig.title}`}
+          description="广泛使用的开源网络安全基础设施"
         >
-          {/* <HomepageHeader/> */}
-          {/* <main> */}
-          <HomePage />
-          {/*<HomepageFeatures/>*/}
-          {/* </main> */}
+          <NewHomePage />
         </Layout>
       )}
     </>

--- a/src/theme/Footer/footer.scss
+++ b/src/theme/Footer/footer.scss
@@ -1,6 +1,6 @@
 .footer {
   height: 72px;
-  background: #f6f7f9;
+  background: var(--hp-paper, #faf6ef);
   padding-top: 24px;
   padding-bottom: 24px;
   width: 100%;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "baseUrl": ".",
     "jsx": "react-jsx",
     "noImplicitAny": false,
-    "strict": false
+    "strict": false,
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "exclude": [".docusaurus", "build", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,7 +1128,7 @@
   dependencies:
     core-js-pure "^3.48.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.7", "@babel/runtime@^7.18.0", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.0", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.22.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.6", "@babel/runtime@^7.23.9", "@babel/runtime@^7.24.4", "@babel/runtime@^7.24.7", "@babel/runtime@^7.24.8", "@babel/runtime@^7.25.7", "@babel/runtime@^7.25.9", "@babel/runtime@^7.26.0", "@babel/runtime@^7.27.6":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.3", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.1", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.7", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.0", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.0", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.22.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.6", "@babel/runtime@^7.23.9", "@babel/runtime@^7.24.4", "@babel/runtime@^7.24.7", "@babel/runtime@^7.24.8", "@babel/runtime@^7.25.7", "@babel/runtime@^7.25.9", "@babel/runtime@^7.26.0", "@babel/runtime@^7.27.6":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -1561,6 +1561,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@csstools/utilities/-/utilities-2.0.0.tgz#f7ff0fee38c9ffb5646d47b6906e0bc8868bde60"
   integrity sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==
+
+"@dimforge/rapier3d-compat@~0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
+  integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
 
 "@discoveryjs/json-ext@0.5.7":
   version "0.5.7"
@@ -2362,6 +2367,18 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
+"@mediapipe/tasks-vision@0.10.17":
+  version "0.10.17"
+  resolved "https://registry.yarnpkg.com/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz#2c1c73ed81902b21d37336a587b96183bb6882d5"
+  integrity sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==
+
+"@monogrid/gainmap-js@^3.0.6":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz#9788a92d34530d3da274fef8d3445d008c640c48"
+  integrity sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==
+  dependencies:
+    promise-worker-transferable "^1.0.4"
+
 "@noble/hashes@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
@@ -2387,6 +2404,18 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@paper-design/shaders-react@^0.0.77":
+  version "0.0.77"
+  resolved "https://registry.yarnpkg.com/@paper-design/shaders-react/-/shaders-react-0.0.77.tgz#b7ed1c8eb3b7ec28a629ad492894a66c233c50af"
+  integrity sha512-VCjhK7k6GT1BMjq7kLsDHMnMy1ryjCTALdhOVIf2Z5b1jh5eEHXqHdQCvMAJ7v6evjiN1twzjM1KUNOg2RoXBw==
+  dependencies:
+    "@paper-design/shaders" "0.0.77"
+
+"@paper-design/shaders@0.0.77":
+  version "0.0.77"
+  resolved "https://registry.yarnpkg.com/@paper-design/shaders/-/shaders-0.0.77.tgz#0598c2e071ac920f7dd3572febeb73fe45116b85"
+  integrity sha512-y0mR3brBu6qvVgbnvBdXX3zL/hajdamkECLt8NbexaEc1L46W3a+ZIEwxu1NJ2/bqwxAgjJC0o2+4CAii5wp/w==
 
 "@parcel/watcher-android-arm64@2.5.6":
   version "2.5.6"
@@ -2713,6 +2742,49 @@
     rc-resize-observer "^1.3.1"
     rc-util "^5.44.0"
 
+"@react-three/drei@^10.7.7":
+  version "10.7.7"
+  resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-10.7.7.tgz#7ac029ace001307dfc71c61b6284b1c12efe8b80"
+  integrity sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mediapipe/tasks-vision" "0.10.17"
+    "@monogrid/gainmap-js" "^3.0.6"
+    "@use-gesture/react" "^10.3.1"
+    camera-controls "^3.1.0"
+    cross-env "^7.0.3"
+    detect-gpu "^5.0.56"
+    glsl-noise "^0.0.0"
+    hls.js "^1.5.17"
+    maath "^0.10.8"
+    meshline "^3.3.1"
+    stats-gl "^2.2.8"
+    stats.js "^0.17.0"
+    suspend-react "^0.1.3"
+    three-mesh-bvh "^0.8.3"
+    three-stdlib "^2.35.6"
+    troika-three-text "^0.52.4"
+    tunnel-rat "^0.1.2"
+    use-sync-external-store "^1.4.0"
+    utility-types "^3.11.0"
+    zustand "^5.0.1"
+
+"@react-three/fiber@^9.6.1":
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-9.6.1.tgz#99dcef884acbad6e3243bab45ae36cd1df0c4b27"
+  integrity sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
+    "@types/webxr" "*"
+    base64-js "^1.5.1"
+    buffer "^6.0.3"
+    its-fine "^2.0.0"
+    react-use-measure "^2.1.7"
+    scheduler "^0.27.0"
+    suspend-react "^0.1.3"
+    use-sync-external-store "^1.4.0"
+    zustand "^5.0.3"
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
@@ -2867,6 +2939,11 @@
   dependencies:
     defer-to-connect "^2.0.1"
 
+"@tweenjs/tween.js@~23.1.3":
+  version "23.1.3"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz#eff0245735c04a928bb19c026b58c2a56460539d"
+  integrity sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==
+
 "@types/body-parser@*":
   version "1.19.6"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
@@ -2903,6 +2980,11 @@
   integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
   dependencies:
     "@types/ms" "*"
+
+"@types/draco3d@^1.4.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@types/draco3d/-/draco3d-1.4.10.tgz#63ec0ba78b30bd58203ec031f4e4f0198c596dca"
+  integrity sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==
 
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
@@ -3073,6 +3155,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
+"@types/offscreencanvas@^2019.6.4":
+  version "2019.7.3"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz#90267db13f64d6e9ccb5ae3eac92786a7c77a516"
+  integrity sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==
+
 "@types/prismjs@^1.26.0":
   version "1.26.6"
   resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.6.tgz#6ea27c126d645319ae4f7055eda63a9e835c0187"
@@ -3087,6 +3174,11 @@
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
+
+"@types/react-reconciler@^0.28.9":
+  version "0.28.9"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.9.tgz#d24b4864c384e770c83275b3fe73fba00269c83b"
+  integrity sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==
 
 "@types/react-router-config@*", "@types/react-router-config@^5.0.7":
   version "5.0.11"
@@ -3179,6 +3271,23 @@
   dependencies:
     "@types/node" "*"
 
+"@types/stats.js@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.4.tgz#1933e5ff153a23c7664487833198d685c22e791e"
+  integrity sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==
+
+"@types/three@*", "@types/three@^0.185.1":
+  version "0.185.1"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.185.1.tgz#cc0e604e56f2c625deabb3984fff932c8d4f39f4"
+  integrity sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==
+  dependencies:
+    "@dimforge/rapier3d-compat" "~0.12.0"
+    "@tweenjs/tween.js" "~23.1.3"
+    "@types/stats.js" "*"
+    "@types/webxr" ">=0.5.17"
+    fflate "~0.8.2"
+    meshoptimizer "~1.1.1"
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -3188,6 +3297,11 @@
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
+
+"@types/webxr@*", "@types/webxr@>=0.5.17", "@types/webxr@^0.5.2":
+  version "0.5.24"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.24.tgz#734d5d90dadc5809a53e422726c60337fa2f4a44"
+  integrity sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==
 
 "@types/ws@^8.5.10":
   version "8.18.1"
@@ -3212,6 +3326,18 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz#0e8f34854df7966b09304a18e808b23997bb9fc1"
   integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
+
+"@use-gesture/core@10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.3.1.tgz#976c9421e905f0079d49822cfd5c2e56b808fc56"
+  integrity sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==
+
+"@use-gesture/react@^10.3.1":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.3.1.tgz#17a743a894d9bd9a0d1980c618f37f0164469867"
+  integrity sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==
+  dependencies:
+    "@use-gesture/core" "10.3.1"
 
 "@webassemblyjs/ast@1.14.1", "@webassemblyjs/ast@^1.14.1":
   version "1.14.1"
@@ -3709,6 +3835,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1, base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 baseline-browser-mapping@^2.10.12:
   version "2.10.37"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
@@ -3718,6 +3849,13 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
+
+bidi-js@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bidi-js/-/bidi-js-1.0.3.tgz#6f8bcf3c877c4d9220ddf49b9bb6930c88f877d2"
+  integrity sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==
+  dependencies:
+    require-from-string "^2.0.2"
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -3819,6 +3957,14 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 bundle-name@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
@@ -3912,6 +4058,11 @@ camelcase@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
+
+camera-controls@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-3.1.2.tgz#fb504fa77ade929aa75c22ba42d0b53f48a81e44"
+  integrity sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -4615,6 +4766,13 @@ destroy@1.2.0, destroy@~1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+detect-gpu@^5.0.56:
+  version "5.0.70"
+  resolved "https://registry.yarnpkg.com/detect-gpu/-/detect-gpu-5.0.70.tgz#db2202d3cd440714ba6e789ff8b62d1b584eabf7"
+  integrity sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==
+  dependencies:
+    webgl-constants "^1.1.1"
+
 detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
@@ -4747,6 +4905,11 @@ dot-prop@^6.0.1:
   integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
+
+draco3d@^1.4.1:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/draco3d/-/draco3d-1.5.7.tgz#94f9bce293eb8920c159dc91a4ce9124a9e899e0"
+  integrity sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -5166,7 +5329,12 @@ feed@^4.2.2:
   dependencies:
     xml-js "^1.6.11"
 
-fflate@^0.8.3:
+fflate@^0.6.9:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.10.tgz#5f40f9659205936a2d18abf88b2e7781662b6d43"
+  integrity sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==
+
+fflate@^0.8.3, fflate@~0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.3.tgz#bc27d8eb30343d4d512abb03480202ce65d825fc"
   integrity sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==
@@ -5262,6 +5430,15 @@ fraction.js@^5.3.4:
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
+
+framer-motion@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.42.2.tgz#8628ad31a9b5c1ea6f908ea1764784e33870b711"
+  integrity sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==
+  dependencies:
+    motion-dom "^12.42.2"
+    motion-utils "^12.39.0"
+    tslib "^2.4.0"
 
 fresh@~0.5.2:
   version "0.5.2"
@@ -5384,6 +5561,11 @@ globby@^13.1.1:
     ignore "^5.2.4"
     merge2 "^1.4.1"
     slash "^4.0.0"
+
+glsl-noise@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/glsl-noise/-/glsl-noise-0.0.0.tgz#367745f3a33382c0eeec4cb54b7e99cfc1d7670b"
+  integrity sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==
 
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
@@ -5606,6 +5788,11 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
+hls.js@^1.5.17:
+  version "1.6.16"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.6.16.tgz#e2e7e79b68357cb3f8aa82dec0a36c9c2701f5c0"
+  integrity sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==
+
 hoist-non-react-statics@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -5804,6 +5991,11 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -5813,6 +6005,11 @@ image-size@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-2.0.2.tgz#84a7b43704db5736f364bf0d1b029821299b4bdc"
   integrity sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
 
 immutable@^5.1.5:
   version "5.1.6"
@@ -6032,6 +6229,11 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-promise@^2.1.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
+  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -6085,6 +6287,13 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+its-fine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-2.0.0.tgz#a90b18a3ee4c211a1fb6faac2abcc2b682ce1f21"
+  integrity sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==
+  dependencies:
+    "@types/react-reconciler" "^0.28.9"
 
 jest-util@^29.7.0:
   version "29.7.0"
@@ -6241,6 +6450,13 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
+lie@^3.0.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
+
 lilconfig@^3.1.1, lilconfig@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
@@ -6322,6 +6538,16 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lucide-react@^1.24.0:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-1.24.0.tgz#5f6da7f37d9107d192e54b7654a99b3468a212c6"
+  integrity sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==
+
+maath@^0.10.8:
+  version "0.10.8"
+  resolved "https://registry.yarnpkg.com/maath/-/maath-0.10.8.tgz#cf647544430141bf6982da6e878abb6c4b804e24"
+  integrity sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==
 
 markdown-extensions@^2.0.0:
   version "2.0.0"
@@ -6612,6 +6838,16 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+meshline@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/meshline/-/meshline-3.3.1.tgz#20decfd5cdd25c8469e862ddf0ab1ad167759734"
+  integrity sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==
+
+meshoptimizer@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-1.1.1.tgz#20c7d050d59bdc573154814f6a37d47d89908cca"
+  integrity sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==
 
 methods@~1.1.2:
   version "1.1.2"
@@ -7122,6 +7358,26 @@ minimist@^1.2.0:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+motion-dom@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.42.2.tgz#b4661b9b3394ae7e990d76dc954bc1e321c59305"
+  integrity sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==
+  dependencies:
+    motion-utils "^12.39.0"
+
+motion-utils@^12.39.0:
+  version "12.39.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.39.0.tgz#e1c66f0e912999804bc5e69b4630c3bc794ef29f"
+  integrity sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==
+
+motion@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.42.2.tgz#7a0954acb1975e1899ad65639a46fc12a3d24999"
+  integrity sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==
+  dependencies:
+    framer-motion "^12.42.2"
+    tslib "^2.4.0"
 
 mrmime@^2.0.0:
   version "2.0.1"
@@ -8136,6 +8392,11 @@ postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.4.47, postcss@^8.4
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+potpack@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.2.tgz#23b99e64eb74f5741ffe7656b5b5c4ddce8dfc14"
+  integrity sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==
+
 pretty-error@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-4.0.0.tgz#90a703f46dd7234adb46d0f84823e9d1cb8f10d6"
@@ -8166,6 +8427,14 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+promise-worker-transferable@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz#2c72861ba053e5ae42b487b4a83b1ed3ae3786e8"
+  integrity sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==
+  dependencies:
+    is-promise "^2.1.0"
+    lie "^3.0.2"
 
 prompts@^2.4.2:
   version "2.4.2"
@@ -8735,6 +9004,11 @@ react-router@5.3.4, react-router@^5.3.4:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-use-measure@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.7.tgz#36b8a2e7fd2fa58109ab851b3addcb0aad66ad1d"
+  integrity sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==
 
 react@^19.0.0:
   version "19.2.7"
@@ -9475,6 +9749,19 @@ srcset@^4.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-4.0.0.tgz#336816b665b14cd013ba545b6fe62357f86e65f4"
   integrity sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==
 
+stats-gl@^2.2.8:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/stats-gl/-/stats-gl-2.4.2.tgz#28a6c869fc3a36a8be608ef21df63c0aad99d1ba"
+  integrity sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==
+  dependencies:
+    "@types/three" "*"
+    three "^0.170.0"
+
+stats.js@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-0.17.0.tgz#b1c3dc46d94498b578b7fd3985b81ace7131cc7d"
+  integrity sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==
+
 "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
@@ -9637,6 +9924,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+suspend-react@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.1.3.tgz#a52f49d21cfae9a2fb70bd0c68413d3f9d90768e"
+  integrity sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==
+
 svg-parser@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -9659,6 +9951,11 @@ swiper@^11.2.1:
   version "11.2.10"
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.2.10.tgz#ed0b17286b56f7fe8d4b46ed61e6e0bd8daaccad"
   integrity sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==
+
+tailwind-merge@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-3.6.0.tgz#88d83242d1dd7bc847223f73dcf210dd1f2ee11c"
+  integrity sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==
 
 tailwindcss@^3.4.17:
   version "3.4.19"
@@ -9732,6 +10029,33 @@ thingies@^2.5.0:
   resolved "https://registry.yarnpkg.com/thingies/-/thingies-2.6.0.tgz#e09b98b9e6f6caf8a759eca8481fea1de974d2b1"
   integrity sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==
 
+three-mesh-bvh@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz#c5e72472e7f062ff79084157a25c122d73184163"
+  integrity sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==
+
+three-stdlib@^2.35.6:
+  version "2.36.1"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.36.1.tgz#7aad805f3de1b8f792274226132bda809fcb15c5"
+  integrity sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==
+  dependencies:
+    "@types/draco3d" "^1.4.0"
+    "@types/offscreencanvas" "^2019.6.4"
+    "@types/webxr" "^0.5.2"
+    draco3d "^1.4.1"
+    fflate "^0.6.9"
+    potpack "^1.0.1"
+
+three@^0.170.0:
+  version "0.170.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.170.0.tgz#6087f97aab79e9e9312f9c89fcef6808642dfbb7"
+  integrity sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==
+
+three@^0.185.1:
+  version "0.185.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.185.1.tgz#63e9e241a17b101e211965121a017b4b4d8054ae"
+  integrity sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==
+
 throttle-debounce@^5.0.0, throttle-debounce@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.2.tgz#ec5549d84e053f043c9fd0f2a6dd892ff84456b1"
@@ -9797,6 +10121,26 @@ trim-lines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
   integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
+troika-three-text@^0.52.4:
+  version "0.52.4"
+  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.52.4.tgz#f7b2389a2067d9506a5757457771cf4f6356e738"
+  integrity sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==
+  dependencies:
+    bidi-js "^1.0.2"
+    troika-three-utils "^0.52.4"
+    troika-worker-utils "^0.52.0"
+    webgl-sdf-generator "1.1.1"
+
+troika-three-utils@^0.52.4:
+  version "0.52.4"
+  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.52.4.tgz#9292019e93cab97582af1cf491c4c895e5c03b66"
+  integrity sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==
+
+troika-worker-utils@^0.52.0:
+  version "0.52.0"
+  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz#ba5525fc444345006ebab0bc9cabdd66f1561e66"
+  integrity sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==
+
 trough@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
@@ -9812,7 +10156,7 @@ tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.1, tslib@^2.6.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -9823,6 +10167,13 @@ tsyringe@^4.10.0:
   integrity sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==
   dependencies:
     tslib "^1.9.3"
+
+tunnel-rat@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tunnel-rat/-/tunnel-rat-0.1.2.tgz#1717efbc474ea2d8aa05a91622457a6e201c0aeb"
+  integrity sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==
+  dependencies:
+    zustand "^4.3.2"
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -10011,6 +10362,11 @@ url-loader@^4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
+use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -10021,7 +10377,7 @@ utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-utility-types@^3.10.0:
+utility-types@^3.10.0, utility-types@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.11.0.tgz#607c40edb4f258915e901ea7995607fdf319424c"
   integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
@@ -10093,6 +10449,16 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
+webgl-constants@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/webgl-constants/-/webgl-constants-1.1.1.tgz#f9633ee87fea56647a60b9ce735cbdfb891c6855"
+  integrity sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==
+
+webgl-sdf-generator@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz#3e1b422b3d87cd3cc77f2602c9db63bc0f6accbd"
+  integrity sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==
 
 webpack-bundle-analyzer@^4.10.2:
   version "4.10.2"
@@ -10323,6 +10689,18 @@ yocto-queue@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
   integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
+
+zustand@^4.3.2:
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.7.tgz#7d6bb2026a142415dd8be8891d7870e6dbe65f55"
+  integrity sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==
+  dependencies:
+    use-sync-external-store "^1.2.2"
+
+zustand@^5.0.1, zustand@^5.0.3:
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.14.tgz#18216c24fcb980cf36898f9c57520e67b1f77855"
+  integrity sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==
 
 zwitch@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## 改动概览

本次 PR 重构官网首页，包含三块主要工作：

### 1. README.md 重写为「官网故事板总稿」
- HERO：Yak Project 是广泛使用的开源网络安全基础设施
- 副 HERO：CDSL-YAK 为网络安全而生的领域编程语言
- 产品矩阵：Yakit / IRify / Memfit AI / JavaJive
- Showcase 演出安排 + 开源故事 Timeline（基于 yaklang/yakit 真实 git 历史考证）
- 用户故事、团队、合作伙伴、品牌视觉规范
- 27 处 \`【TODO 配图/视频】\` 占位，便于运营补齐素材

### 2. Hero 区视觉升级
- 新增 \`Hero24\` 布局（左内容 + 右背景）
- 背景从 NeuroNoise 替换为 react-bits **Watercolor** 着色器
- 品牌橙配色（\`#ff7d23\` + \`#ffb380\`），密度/对比度按官方 demo 调优
- 关键词条紧凑排列、靠左、等间距

### 3. Tab 式下载面板（参照 react-bits download-8 终端美学）
- 产品切换：Yakit / Yaklang / IRify / Memfit，默认 Yakit
- 终端风格平台切换（macOS / Windows / Linux），默认按 \`navigator.userAgent\` 高亮当前系统
- Yakit 实时拉取最新版本号与各平台安装包体积
- Yaklang 一行安装命令（可一键复制）
- 底部可展开「下载兼容版本（旧系统）」
- 三列 guarantees 说明

## 技术接入
- 接入 react-bits Pro 组件：\`watercolor\` / \`mosaic\` / \`staggered-text\`（AGPL-3.0）
- 配置 shadcn registry（\`components.json\`）与 \`@/*\` 路径别名
- 新增 \`src/lib/utils.ts\` 的 \`cn()\` 工具
- 依赖：\`motion\` / \`lucide-react\` / \`three\` / \`@react-three/fiber\` / \`tailwind-merge\` / \`@types/three\`

## 备注
- \`.env.local\`（含 react-bits license key）已被 \`.gitignore\` 忽略，未入库
- \`README.md.bak\` 为原 README 备份，保留为未跟踪文件，未入库
- \`DownloadBlock.tsx\` 顶部加 \`@ts-nocheck\`（与现有 \`download.tsx\` 一致）

## 验证
- \`npx tsc --noEmit\` 本次改动相关无新增报错
- \`yarn start\` 本地 \`localhost:3000\` 编译通过，页面可访问